### PR TITLE
fix wrong url in termine.tex

### DIFF
--- a/src/termine.tex
+++ b/src/termine.tex
@@ -15,9 +15,9 @@
     \fi
 \fi
 
-\ifml 
+\ifml
 	\item~ % Funktioniert nicht anders, don't judge me
-\else 
+\else
 	\item[Montag, 30. September \YEAR, 10:00 Uhr, Sand 6, Raum F119]\ \\
 	Heute beginnt der Vorbereitungskurs Mathematik. Es ist nicht Pflicht daran teilzunehmen,
 	es ist aber sehr empfehlenswert. Nicht zuletzt lernst du hier erste Freunde kennen!
@@ -33,7 +33,7 @@
 	\textbf{Wenn du deinen Bachelor nicht an der Universität Tübingen oder in einem anderen Fach erworben hast, kann der Vorkurs für dich sinnvoll sein. Auf unserer Website findest du ein Skript, von dem ein Teil auch im Vorkurs besprochen wird. Damit solltest du einschätzen können, wie viel vom Stoff bereits bekannt ist und ob sich der Besuch des Vorkurses lohnt.}
 	\fi
 	Um am Vorkurs teilzunehmen, musst du dich bis zum 20.09. \YEAR~anmelden.\\
-    \url{https://www.uni-tuebingen.de/91877}.
+    \url{https://www.uni-tuebingen.de/de/91877}.
 	% Um Anmeldung wird gebeten, sie ist aber nicht zwingend erforderlich.
 
 	\ifsommersemester
@@ -41,9 +41,9 @@
 	Bitte beachtet, dass das Semesterticket \emph{erst ab dem 1.4} gültig ist. Falls du davor Tübingen schon unsicher machst und Bus fahren willst, musst du dir extra Fahrscheine kaufen.
 	%Natürlich kommt man zur Morgenstelle auch zu Fuß oder mit dem Rad, da es jedoch steil den Berg hochgeht, muss man hierfür einiges an Zeit einrechnen.
 	\fi
-	
+
 	\seticon{faBus}~\textbf{Bushaltestelle:} Linie 2, "`Sand Drosselweg"' (Rest ausgeschildert)
-\fi 
+\fi
 
 \ifwintersemester
     \ifmaster
@@ -56,34 +56,34 @@
     \fi
 \fi
 
-\ifml 
+\ifml
 	\item[Tuesday, October 2nd, \YEAR, 19:00, Sand 14, room A104 (meeting point is signposted)]\ \\
-	On this evening still early into the semester, we would like to invite you to a cozy movie night at the Sand. This is a perfect opportunity to relax, get to know the Sand, meet the people of the student council and future co-eds while watching a movie \footnote{Due to license restrictions, we're not allowed to tell you what movie wil be shown}. 
-	
+	On this evening still early into the semester, we would like to invite you to a cozy movie night at the Sand. This is a perfect opportunity to relax, get to know the Sand, meet the people of the student council and future co-eds while watching a movie \footnote{Due to license restrictions, we're not allowed to tell you what movie wil be shown}.
+
 	\seticon{faBus}~\textbf{bus stop:} route 2, "`Sand Drosselweg"' (signposted from there)
-\else 
+\else
 	\item[Mittwoch, 2. Oktober \YEAR, 19:00 Uhr, Sand 14, Raum A301]\ \\
 	Am Abend des vierten Vorkurstages möchten wir dich zu einem gemütlichen Filmabend auf dem Sand einladen.
 	Hier hast du die Möglichkeit, bei einem Film \footnote{welcher Film gezeigt wird, dürfen wir aus lizenzrechtlichen Gründen nicht bekannt geben.} zu entspannen, einige Fachschaftler, den Sand und eure zukünftigen Kommilitonen kennen zu lernen.
 
 	\seticon{faBus}~\textbf{Bushaltestelle:} Linie 2, Sand Drosselweg (Rest ausgeschildert)
-\fi 
+\fi
 
 
 \ifml
 	\item[Friday, October 4th, \YEAR, 19:00, Sand]\ \\
 	We'd like to invite you to (an analog) board game evening with relaxed atmosphere at the Sand. We'll provide some games as well as drinks and snacks (for a small donation). Even though our collection is growing steadily, we're more than happy if you bring along your own games! Further details will be provided at \url{https://www.fsi.uni-tuebingen.de/ersti}.
-	
+
 	\seticon{faBus}~\textbf{bus stop:} route 2, "`Sand Drosselweg"' (signposted from there)
-\else 
+\else
 	\item[Freitag, 4. Oktober \YEAR, 19:00, Sand]\ \\
 	Wir möchten dich zu einem kleinen (analog-) Spieleabend mit guter Gesellschaft und entspannter Atmosphäre auf dem Sand einladen. Für einige Spiele sowie Getränke und Knabberkram (gegen einen kleinen Obolus) sorgt die Fachschaft. Wir freuen uns natürlich sehr, wenn du auch eigene Spiele mitbringst, obwohl unsere Sammlung schon beachtlich ist! Details werden noch auf \url{https://www.fsi.uni-tuebingen.de/ersti/} bekannt gegeben.
-	
+
 	\seticon{faBus}~\textbf{Bushaltestelle:} Linie 2, Sand Drosselweg (Rest ausgeschildert)
-\fi 
+\fi
 
 % Bus-Schnitzeljagd, neu im WS19/20
-\ifml 
+\ifml
 	\item[Monday, October 7th \YEAR, 19:00, \textbf{in front of} Neckarmüller]\ \\
     During a scavenger hunt you will be sent off in teams to explore the Tübingen bus network. By solving various puzzles, you will not only get to know your new fellow students better, but also get to know some stops that you will encounter more or less frequently in your everyday university life. Since students in Tübingen (and in the complete naldo area) are allowed to take the bus and train free of charge from Monday to Friday from 19:00 \footnote{as well as all day on Saturdays, Sundays and public holidays in Baden-Württemberg} onwards, you only need your student ID card for your exploration tour.\\
 If details change, you will find further information such as time and meeting point on our website \url{https://www.fsi.uni-tuebingen.de/ersti/}.\\
@@ -92,40 +92,40 @@ If details change, you will find further information such as time and meeting po
 	\item[Montag, 7. Oktober \YEAR, 19:00 Uhr, vor dem Neckarmüller]\ \\
     Bei der Schnitzeljagd wirst du mit deinen Kommilitonen in Teams losgeschickt, um das Tübinger Busnetz zu erkunden. Durch das Lösen verschiedener Rätsel lernt ihr dabei nicht nur eure neuen Komilitonen sondern auch einige Haltestellen besser kennen, die euch in eurem Uni-Alltag mehr oder weniger häufig begegnen werden. Da Studenten in Tübingen (und im kompletten naldo-Bereich) montags bis freitags ab 19:00 Uhr \footnote{sowie ganztägig an Samstagen, Sonntagen und gesetzlichen Feiertagen in Baden-Württemberg} kostenlos Bus und Bahn fahren dürfen, benötigt ihr für eure Erkundungstour lediglich euren Studierendenausweis.\\
     Falls sich Details ändern sollten, findest du weitere Infos wie Uhrzeit und Treffpunkt auf unserer Webseite \url{https://www.fsi.uni-tuebingen.de/ersti}.\\
-\fi 
+\fi
 
 
 %Stadtrallye
-\ifml 
+\ifml
 	\item[Wednesday, October 9th \YEAR, 19:00 Uhr, \textbf{in front of} Neckarmüller ]\ \\
 	On this evening, you can participate in a team-based scavenger hunt across the city, where you will get to know interesting, beautiful as well as disturbing spots within Tübingen. As a side effect, you will hopefully get to know your new home town a bit better and make new friends. The meeting point is at the Neckarbrücke \emph{in front of the} restaurant "`Neckarmüller"`.
 	If the schedule (time and meeting point) should change somehow, you will find the new details on our website at \url{https://www.fsi.uni-tuebingen.de/ersti/}.
-	
+
 	\seticon{faBus}~\textbf{bus stop:} route 2, "`Sand Drosselweg"' (signposted from there)
 \else
 	 \item[Mittwoch, 9. Oktober \YEAR, 19:00 Uhr, \textbf{vor} dem Neckarmüller ]\ \\
 	 Bei der Stadtrallye lassen wir dich und deine Kommilitonen gegeneinander in Teams antreten. Dabei werdet ihr interessante, schöne und verstörende Ecken Tübingens kennen lernen, dabei hoffentlich die Orientierung in eurer neuen Heimat etwas verbessern und Kontakte knüpfen. Der Treffpunkt ist bei der Neckarbrücke (\emph{vor} dem Gasthaus „Neckarmüller“).
-	 Falls sich Details ändern sollten, findest du weitere Infos wie Uhrzeit und Treffpunkt auf unserer Webseite \url{https://www.fsi.uni-tuebingen.de/ersti/}.	 
-\fi 
+	 Falls sich Details ändern sollten, findest du weitere Infos wie Uhrzeit und Treffpunkt auf unserer Webseite \url{https://www.fsi.uni-tuebingen.de/ersti/}.
+\fi
 
 % Frühstück
-\ifml 
+\ifml
 % Frühstück Master ML
     \item[Friday, October 11th \YEAR, 9:00, Mensa Morgenstelle]\ \\
         Let's have breakfast together, we're paying! You will get to know a lot of stuff about the university, the student council, what it's like to study in Tübingen and what you can expect in the upcoming months -- especially when talking to older co-eds.
-    \ifwintersemester You will also be greeted by \Infoprof~-- he will lecture Informatics I. This is a lecture for bachelor students, but maybe you will get to know him in other lectures as well. \fi  
+    \ifwintersemester You will also be greeted by \Infoprof~-- he will lecture Informatics I. This is a lecture for bachelor students, but maybe you will get to know him in other lectures as well. \fi
     Afterwards, we will provide a tour of the Morgenstelle so you get to know the most important rooms and lecture halls.
     You can reach the Morgenstelle via bus, bicycle or on foot. However, the way up to the Morgenstelle is quite steep -- Tübingen is hilly (German: \emph{hügelig}), so you should factor in the time you need to get there.
-    The simplest (but also steepest) way is via "`Parkhaus König"' and up "`Schnarrenbergstraße"', past the university hospital. If you're starting at Waldhäuser Ost, follow the "`Nordring"' in direction of "`Uni-Morgenstelle"' / "`Kliniken Berg"'. 
+    The simplest (but also steepest) way is via "`Parkhaus König"' and up "`Schnarrenbergstraße"', past the university hospital. If you're starting at Waldhäuser Ost, follow the "`Nordring"' in direction of "`Uni-Morgenstelle"' / "`Kliniken Berg"'.
     If you want to drive there by car, you can park (not free!) by the side of the road on Nordring or inside the multi-story cark park "`Ebenhalde"' north of the Morgenstelle. However, the simplest way is via bus.
     From 11:45 onwards, you can try out the mensa food if you like.\\
     \seticon{faBus}~\textbf{bus stop:} BG Unfallklinik (bus routes 5, 13, 14, 17, 18, 19, X15)
 
-\else  
+\else
     \item[Freitag, 11. Oktober \YEAR, 9:00 Uhr, Mensa Morgenstelle]\ \\
-        Wir laden dich an diesem Morgen zu einem gemütlichen Frühstück ein! Dabei erfährst du einiges über die Uni, die Fachschaft und was dich in den nächsten Monaten erwartet -- auch im Gespräch mit älteren Studierenden. 
-    \ifwintersemester Außerdem wirst du durch \Infoprof~-- er wird die Informatik I Vorlesung halten -- begrüßt. \fi 
-    \ifsommersemester Außerdem wirst du durch \Infoprof~-- er wird die Informatik II Vorlesung halten -- begrüßt. \fi 
+        Wir laden dich an diesem Morgen zu einem gemütlichen Frühstück ein! Dabei erfährst du einiges über die Uni, die Fachschaft und was dich in den nächsten Monaten erwartet -- auch im Gespräch mit älteren Studierenden.
+    \ifwintersemester Außerdem wirst du durch \Infoprof~-- er wird die Informatik I Vorlesung halten -- begrüßt. \fi
+    \ifsommersemester Außerdem wirst du durch \Infoprof~-- er wird die Informatik II Vorlesung halten -- begrüßt. \fi
     \ifmaster Zwar ist Informatik I eine Bachelor-Veranstaltung, aber du wirst \Infoprof~ vielleicht auch in Master-Vorlesungen kennen lernen. \fi
     \ifwintersemester
         Danach machen wir eine Führung über die Morgenstelle, damit du die wichtigsten Räume und Hörsäle kennen lernst.
@@ -135,9 +135,9 @@ If details change, you will find further information such as time and meeting po
         Wenn du Lust hast, kannst du ab 11:45 Uhr das Mensaessen ausprobieren.
     \fi
 
-    \ifwintersemester \seticon{faBus}~\textbf{Bushaltestelle:} BG Unfallklinik (Linie 5, 13, 14, 17, 18, 19, X15) \fi 
-    \ifsommersemester \seticon{faBus}~\textbf{Bushaltestelle:} Linie 2, Sand Drosselweg \fi 
-\fi 
+    \ifwintersemester \seticon{faBus}~\textbf{Bushaltestelle:} BG Unfallklinik (Linie 5, 13, 14, 17, 18, 19, X15) \fi
+    \ifsommersemester \seticon{faBus}~\textbf{Bushaltestelle:} Linie 2, Sand Drosselweg \fi
+\fi
 
 \iflehramt
     \item[Freitag, 11. Oktober \YEAR, 10:00-12:00 Uhr, Kupferbau, Hörsaal 25]\ \\
@@ -149,19 +149,19 @@ If details change, you will find further information such as time and meeting po
         Wenn du im \textbf{Master of Education} studierst, kannst du zum Frühstück bleiben, eure Einführungsveranstaltung beginnt dann erst um 14 Uhr. Hier bekommst du u.a. einen Einblick in die verschiedenen Studienanteile des Master of Education und Informationen zum Schulpraxissemester.
 \fi
 
-\ifml 
+\ifml
 	\item[Friday, October 11th, \YEAR, 14:00, Sand, Foyer (rooms and schedule will follow)]\ \\
 	At 2 o'clock, we'll meet up again at the Sand, home of the faculty of computer science. % Ich weiß dass es keine Fakultät ist, übersetz mir mal einer Fachbereich...
-	Here you can gain some interesting insights into the work of the different work groups present at the Sand. 
+	Here you can gain some interesting insights into the work of the different work groups present at the Sand.
 	Getting to know the work groups makes sense for ML as well, depending on how you want to focus your studies or thesis. Depending on your interests you can participate in different mini workshops or listen to talks, however, this requires some planning on your part. The talks available (as well as the time slots) are subject to change, please refer to \url{https://www.fsi.uni-tuebingen.de/ersti/} the day before.
-	For the most part, the work groups focusing on Machine Learning are located at the Tübinen AI research building, however, access there is rather restricted. 
+	For the most part, the work groups focusing on Machine Learning are located at the Tübinen AI research building, however, access there is rather restricted.
 
 	\seticon{faBus}~\textbf{bus stop:} route 2, "`Sand Drosselweg"' (signposted from there)
-\else 
+\else
 	\item[Freitag, 11. Oktober \YEAR, 14 Uhr, Sand, Foyer (Räume und Programm folgen)]\ \\
 	Um 14:00 treffen wir uns auf dem Sand (dem Sitz der Informatik in Tübingen) wieder. Hier werden wir dich mit Informationen rund um das Studium und die Arbeit unserer Lehrstühle auf dem Sand versorgen.
 	Nachdem du über den Verlauf des Studiums der ersten Wochen, Monate und Semester informiert wurdest, bieten dir die verschiedenen Fachbereiche mit interaktiven Vorträgen einen Einblick in ihre Arbeit. Die Fachbereiche kennen zu lernen lohnt sich für Studierende aller Studiengänge. Die Vorträge zeigen, welche Themen am Wilhelm-Schickard-Institut verfolgt werden, geben dir ein Gefühl, was für dich hier interessant sein kann und wo du möglicherweise Schwerpunkte im Studium, einer Studien- oder Abschlussarbeit setzen willst. Je nach Interesse kannst du dir verschiedene Vorträge anhören, allerdings bedarf dies an Auswahl und Planung von deiner Seite. Die angebotenen Vorträge können sich thematisch oder, wie die Begrüßungen, im Zeitrahmen ändern. Schau daher auch kurzfristig (am selben Tag) auf \url{https://www.fsi.uni-tuebingen.de/ersti/} nach.
-	
+
     \seticon{faBus}~\textbf{Bushaltestelle:} Linie 2, Sand Drosselweg (Rest ausgeschildert)
 \fi
 
@@ -169,13 +169,13 @@ If details change, you will find further information such as time and meeting po
     \ifml
         \item[Friday, October 11th \YEAR, 11:00, Maria-von-Linden-Straße 6]\ \\
     At this informal meeting you will have the opportunity to get to know your fellow students and some of the lecturers over a coffee. And then there will be cake.\footnote{This is not a lie!}
-	
+
         \seticon{faBus}~\textbf{bus stop:} route 3, "`Maria-von-Linden-Straße"' (signposted from there)
     \else
 %Mastercafé
     \item[Freitag, 11. Oktober \YEAR, 15:30, Sand 1, A301]\ \\
     Bei diesem informellen Treffen hast du Gelegenheit, neue Master-Studierende aus deinem eigenen und auch aus anderen Studiengängen sowie einige der Dozenten bei Kaffee kennenzulernen. Und dann gibt es Kuchen. \footnote{Das ist keine Lüge!}
-	 
+
         \seticon{faBus}~\textbf{Bushaltestelle:} Linie 2, Sand Drosselweg (Rest ausgeschildert)
     \fi
 \fi
@@ -201,15 +201,15 @@ If details change, you will find further information such as time and meeting po
 %\seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Rest ausgeschildert)
 
 % Kneipentour
-\ifml 
+\ifml
 	\item[Friday, October 11th \YEAR, 18:00, \textbf{in front of} Neckarmüller]\ \\
         Tübingen is laced with small bars and pubs that have a significant impact on the night life in Tübingen. In order to calm down from the stress of this information-filled day, we'd like to invite you to go bar-hopping with us. We'll divide up into small groups and visit the different bars in the historic town center. Please bring enough cash, most places we will visit don't accept cards (\emph{none whatsoever}).
 
-	\else 
+	\else
 	\item[Freitag, 11. Oktober \YEAR, 18:00 Uhr, \textbf{vor} dem Neckarmüller]\ \\
         Tübingen ist übersät mit kleinen Kneipen und Bars, die das Nachtleben maßgeblich beeinflussen. Um den Stress des informationsgefüllten Tages etwas sacken zu lassen, laden wir dich zu einer ausgiebigen Kneipentour ein, bei der wir in Kleingruppen die verschiedenen Lokalitäten der Tübinger Altstadt besuchen. Bitte bringe genügend Bargeld mit, man kann in fast keiner der Tübinger Bars mit EC-Karte zahlen! -- Volksbanken und Sparkassen finden sich bei Bedarf in der Stadt.
 
-	\fi 
+	\fi
 
     % erste Vorlesung
 \ifbachelor
@@ -230,13 +230,13 @@ Alles, was du heute (und in Zukunft) benötigst: persönlichen Wachmacher, einen
     Hier stellen sich die kognitionswissenschaftlichen Lehrstühle (also die verschiedenen Forschungsbereiche der Professoren) vor. Dies ist super um einen Überblick zu bekommen, was die Kognitionswissenschaft alles beinhaltet und um erste Eindrücke von den Profs zu bekommen. Auch die Fachschaft stellt sich dir hier erstmals vor. Danach gibt es noch Gelegenheit, mit der Fachschaft ein Glas Milch trinken zu gehen. Auch für Kogni-Master ist das eine super Veranstaltung.
 \fi
 
-\ifml 
+\ifml
 	\item[Tuesday, October 15th \YEAR, 17:00, Sand 13, garden]\ \\
-	You're not in the mood for cooking this evening? Fear not! The student coucil invites you for a BBQ. Bring whatever you want to put on the grill, please also bring your own plates and cutlery. The garden has enough space for stuff like volleyball, football etc. as well. 
+	You're not in the mood for cooking this evening? Fear not! The student coucil invites you for a BBQ. Bring whatever you want to put on the grill, please also bring your own plates and cutlery. The garden has enough space for stuff like volleyball, football etc. as well.
 	If the schedule should change somehow, you can find updated details on our website at \url{https://www.fsi.uni-tuebingen.de/ersti/}.
-	
+
 	\seticon{faBus}~\textbf{bus stop:} route 2, "`Sand Drosselweg"' (signposted from there)
-\else 
+\else
 	\item[Dienstag, 15. Oktober \YEAR, 17:00 Uhr, im Garten des Sandes ]\ \\
 	Du hast keinen Bock auf Kochen? Dann bist du hier genau richtig! In geselliger Runde wird die Fachschaft mit dir grillen. Bringt dazu mit, was auch immer du zum Grillen brauchst, Gas- und Kohlegrill warten auf dich. Bring bitte auch dein Besteck und Geschirr selbst mit!\\
 	 Auf dem Sand ist es auch möglich, Volleyball, Fußball, usw. zu spielen. Wir freuen uns auf dich!
@@ -258,7 +258,7 @@ Alles, was du heute (und in Zukunft) benötigst: persönlichen Wachmacher, einen
 	\seticon{faBus}~\textbf{bus stop:} route 2, "`Sand Drosselweg"' (signposted from there)
 \else
     \item[Donnerstag, 17. Oktober \YEAR, 18:00 Uhr, Sand 13, A301]\ \\
-An diesem Nachmittag/Abend möchten wir dich zunächst auf den Sand einladen, um in gemütlicher Runde mit anderen Kommilitonen und Fachschaftlern Brett- und Gesellschaftsspiele zu spielen. Sobald die Zeit an diesem Abend ausreichend fortgeschritten ist, möchten wir zusammen mit dir ein wenig die Kneipen der Altstadt unsicher machen. 
+An diesem Nachmittag/Abend möchten wir dich zunächst auf den Sand einladen, um in gemütlicher Runde mit anderen Kommilitonen und Fachschaftlern Brett- und Gesellschaftsspiele zu spielen. Sobald die Zeit an diesem Abend ausreichend fortgeschritten ist, möchten wir zusammen mit dir ein wenig die Kneipen der Altstadt unsicher machen.
 
 \seticon{faBus}~\textbf{Bushaltestelle:} Linie 2, Sand Drosselweg (Rest ausgeschildert)
 \fi
@@ -294,7 +294,7 @@ An diesem Nachmittag/Abend möchten wir dich zunächst auf den Sand einladen, um
         Every Thursday during the lecture period, a different student body or group of students organizes the "`Clubhaus Fest"'\footnote{a university building where a different student council hosts a party every thursday} in the Clubhaus, directly opposite the New auditorium. Today the attendance is particularly worthwhile, because the student councils of computer science, cognitive science and psychology are hosts! We are looking forward to meeting you!
 
         \seticon{faBus}~\textbf{bus stop:} Uni/Neue Aula or Hölderlinstraße
-\else 
+\else
     \item[Donnerstag, 24. Oktober \YEAR, 18 Uhr, Clubhaus ]\ \\
         Während der Vorlesungszeit richtet jeden Donnerstag eine andere Fachschaft oder studentische Gruppierung das Clubhausfest im Clubhaus, direkt gegenüber der Neuen Aula, aus. Heute lohnt sich der Besuch jedoch ganz besonders, denn die Fachschaften Informatik, Kogni und Psychologie sind Gastgeber! Wir freuen uns auf dich!
 %Das anfängliche Chaos des Vorlesungsbeginns hat sich gelegt und auch an diesem Donnerstag findet das Clubhausfest statt.
@@ -309,7 +309,7 @@ An diesem Nachmittag/Abend möchten wir dich zunächst auf den Sand einladen, um
 \else
     \item[Freitag, 25. Oktober \YEAR, 19:00 Uhr, Neckarbrücke]\ \\
         Weil die Kneipenlandschaft in Tübingen so mannigfaltig ist, dass es an einem Abend unmöglich ist, überall mal gewesen zu sein, gibt es an diesem Abend eine Fortsetzung. Treffpunkt ist wieder an der Neckarbrücke vor dem Neckarmüller. Auch hier gilt: bitte genug Bargeld mitnehmen!
-\fi        
+\fi
 
 %\ifkogwiss
 %


### PR DESCRIPTION
There was a typo in the URL for the Vorkurs. This has to be fixed ASAP, since the deadline for application is Friday.