### PR TITLE
Note on Ersti events

### DIFF
--- a/src/termine.tex
+++ b/src/termine.tex
@@ -1,4 +1,11 @@
 \begin{description}
+  % HINWEIS ZUR ANMELDUNG - GILT IMMER - NICHT LÖSCHEN
+  \ifml
+    \textbf{Note:} Unless stated otherwise (i.e. in the description of the event itself), explicitly signing up for the events of the student council is usually \textbf{not necessary}. Details on the respective event can always be found at \url{https://www.fsi.uni-tuebingen.de/ersti} as well.
+  \else
+    \textbf{Hinweis:} Sofern nicht anders angegeben (z.B. im Text der jeweiligen Veranstaltung), ist eine explizite Anmeldung zu den Anfi-Veranstaltungen der Fachschaft normalerweise \textbf{nicht nötig}. Weitere Details zur jeweiligen Veranstaltung finden sich auch immer auf \url{https://www.fsi.uni-tuebingen.de/ersti}.
+  \fi
+  % ENDE HINWEIS ZUR ANMELDUNG
 
 \ifkogwiss
     \ifmaster

--- a/src/termine.tex
+++ b/src/termine.tex
@@ -1,9 +1,9 @@
 \begin{description}
   % HINWEIS ZUR ANMELDUNG - GILT IMMER - NICHT LÖSCHEN
   \ifml
-    \textbf{Note:} Unless stated otherwise (i.e. in the description of the event itself), explicitly signing up for the events of the student council is usually \textbf{not necessary}. Details on the respective event can always be found at \url{https://www.fsi.uni-tuebingen.de/ersti} as well.
+    \item[Note:] Unless stated otherwise (i.e. in the description of the event itself), explicitly signing up for the events of the student council is usually \textbf{not necessary}. Details on the respective event can always be found at \url{https://www.fsi.uni-tuebingen.de/ersti} as well.
   \else
-    \textbf{Hinweis:} Sofern nicht anders angegeben (z.B. im Text der jeweiligen Veranstaltung), ist eine explizite Anmeldung zu den Anfi-Veranstaltungen der Fachschaft normalerweise \textbf{nicht nötig}. Weitere Details zur jeweiligen Veranstaltung finden sich auch immer auf \url{https://www.fsi.uni-tuebingen.de/ersti}.
+    \item[Hinweis:] Sofern nicht anders angegeben (z.B. im Text der jeweiligen Veranstaltung), ist eine explizite Anmeldung zu den Anfi-Veranstaltungen der Fachschaft normalerweise \textbf{nicht nötig}. Weitere Details zur jeweiligen Veranstaltung finden sich auch immer auf \url{https://www.fsi.uni-tuebingen.de/ersti}.
   \fi
   % ENDE HINWEIS ZUR ANMELDUNG
 
@@ -26,7 +26,7 @@
 	\item~ % Funktioniert nicht anders, don't judge me
 \else
 	\item[Montag, 30. September \YEAR, 10:00 Uhr, Sand 6, Raum F119]\ \\
-	Heute beginnt der Vorbereitungskurs Mathematik. Es ist nicht Pflicht daran teilzunehmen,
+  Heute beginnt der Vorbereitungskurs Mathematik. Es ist nicht Pflicht daran teilzunehmen,
 	es ist aber sehr empfehlenswert. Nicht zuletzt lernst du hier erste Freunde kennen!
 	\ifsommersemester
 	Der Vorkurs bietet dir eine Wiederholung des Schulstoffes sowie eine Übersicht über den Stoff von Mathe II


### PR DESCRIPTION
This PR will introduce a note at the top of `termine.tex`, stating that explicitly signing up for our events is usually not needed (hopefully this will prevent people from asking about it in the future).