### PR TITLE
Fix failing build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ RELEASEDIR = final
 
 # Test ob Inkscape installiert ist
 INKSCAPE := $(shell inkscape --version 2> /dev/null)
-# Test ob pdftk installiert ist
-PDFTK := $(shell pdftk --version 2> /dev/null)
 
 # Liste was wo erstellt werden soll:
 PLAENE = stpl_uebersicht stadtplan
@@ -89,15 +87,8 @@ ifndef INKSCAPE
 	echo '\shipout\hbox{}\end' | pdftex && mv texput.pdf $(PDFDIR)/stadtplan.pdf
 else
 	if [ ! -d $(OUTDIR) ]; then mkdir $(OUTDIR); fi
-	inkscape -C -T $(MEDIADIR)/stadtplan.svg -A $(OUTDIR)/stadtplan.tmp
-  ifndef PDFTK
-	$(warning pdftk is missing! Skipping $@)
-	# Generate an empty PDF document for the rest of the build process:
-	echo '\shipout\hbox{}\end' | pdftex && mv texput.pdf $(PDFDIR)/stadtplan.pdf
-  else
-	if [ ! -d $(PDFDIR) ]; then mkdir $(PDFDIR); fi
-	pdftk $(OUTDIR)/stadtplan.tmp update_info $(MEDIADIR)/stadtplan.info output $(PDFDIR)/stadtplan.pdf
-  endif
+	inkscape -C -T $(MEDIADIR)/stadtplan.svg --export-pdf=$(OUTDIR)/stadtplan.pdf
+	mv $(OUTDIR)/stadtplan.pdf $(PDFDIR)/stadtplan.pdf
 endif
 
 # Mit diesem Target lässt sich ein bestimmter Brief erstellen
@@ -149,11 +140,6 @@ ifndef INKSCAPE
 	@echo '- Warning: Inkscape is missing!'
 else
 	@echo '- Inkscape is installed.'
-endif
-ifndef PDFTK
-	@echo '- Warning: pdftk is missing!'
-else
-	@echo '- pdftk is installed.'
 endif
 	@echo 'Output directory (for auxiliary files): $(OUTDIR)'
 	@echo 'PDF directory: $(PDFDIR)'

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ ifndef INKSCAPE
 	echo '\shipout\hbox{}\end' | pdftex && mv texput.pdf $(PDFDIR)/stadtplan.pdf
 else
 	if [ ! -d $(OUTDIR) ]; then mkdir $(OUTDIR); fi
-	inkscape -C -T $(MEDIADIR)/stadtplan.svg --export-pdf=$(OUTDIR)/stadtplan.pdf
+	inkscape -C -T $(MEDIADIR)/stadtplan.svg --export-file=$(OUTDIR)/stadtplan.pdf
 	mv $(OUTDIR)/stadtplan.pdf $(PDFDIR)/stadtplan.pdf
 endif
 


### PR DESCRIPTION
Inkscape is capable of directly converting SVG to PDF files.
Since at least version > 0.92.1, the current Makefile does not work as
expected and probably produces a PDF in $(OUTDIR)/stadtplan.tmp.
Also remove all references to PDFtk because we don't need it anymore
(since Inkscape is converting the SVG to a PDF directly).
See Travis build https://travis-ci.org/fsi-tue/anfibrief/builds/653176728.