### PR TITLE
Fix the Nix CI build with TeX Live 2019

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       inherit (texlive) scheme-minimal latexmk latexconfig latex koma-script
         graphics german xcolor bera collection-fontsrecommended fontawesome
         geometry oberdiek totpages ms setspace microtype hyphenat pdfpages tools
-        url hyperref;
+        url hyperref babel babel-german hyphen-german;
     })
   ];
 

--- a/src/stpl_uebersicht.tex
+++ b/src/stpl_uebersicht.tex
@@ -1,6 +1,6 @@
-\documentclass[10pt]{scrartcl}
+\documentclass[10pt]{article}
 \usepackage[utf8]{inputenc}
-\usepackage{german}
+\usepackage[ngerman]{babel}
 \usepackage[left=2.5cm,right=2.5cm,top=2cm,bottom=2.5cm]{geometry}
 \setcounter{secnumdepth}{0}
 
@@ -14,7 +14,7 @@
 \input{stundenplaene/stpl_informatik-bsc}
 \subsection{Bioinformatik}
 \input{stundenplaene/stpl_bioinfo-bsc}
-\pagebreak
+\newpage
 \subsection{Medieninformatik}
 \input{stundenplaene/stpl_medieninfo-bsc}
 \subsection{Kognitionswissenschaft}


### PR DESCRIPTION
Since TeX Live 2019 the KOMA-Script class `scrartcl` seems to cause
errors that make the build fail [0]. I didn't manage to figure out what
exactly is going wrong, but since `scrartcl` tends to cause such
problems it seems best to switch to the core document class `article`
anyway (causes way fewer problems in general - at least IMO).

This obviously causes a few visual differences (the headings look a bit
less "nice" and the indentation is a bit larger for both paragraphs and
footnotes), but the result doesn't change significantly (without a
direct comparison it normally shouldn't be noticeable).
I switched to Babel for proper hyphenation (avoids too long lines), and
replaced a "\pagebreak" with "\newpage" to fix the position of the
footnote.

[0]: https://travis-ci.org/fsi-tue/anfibrief/builds/653176728

cc: @luoe: This is orthogonal to #34 and fixes the Nix CI error instead of the Inkscape error.