### PR TITLE
content update for summer term 2026

### DIFF
--- a/src/config.tex
+++ b/src/config.tex
@@ -5,10 +5,13 @@
 % 1. Professoren eintragen
 % Titel mit eintragen, damit man in den Terminen nicht If-en muss falls Britta Mathe hält
 % Info & Mathe
-\newcommand{\Matheprof}{Prof. Martius}
-\newcommand{\Infoprof}{Prof. Ostermann}
-% Technische Info
-\newcommand{\TechInfoprof}{Prof. Bringmann}
+\newcommand{\Matheprof}{Dr. Dorn}
+\newcommand{\Infoprof}{Dr. Schuster}
+\newcommand{\TechInfoprof}{Prof. Menth}
+% Bioinfo 
+\newcommand{\Biochemieprof}{Prof. Nürnberger}
+% Lehramt lol
+\newcommand{\Didaktikprof}{Prof. Knobelsdorf}
 % Kogwiss: Tierphys, Computergestützte Statistik I, Einführung Kognitionswissenschaften, Statistik 1
 \newcommand{\Tierphysprof}{Prof. Nieder}
 \newcommand{\CompStaprof}{Julian Mollenhauer, Frieder Göppert}
@@ -17,27 +20,27 @@
 
 % 2. Ticketpreise anpassen
 % Link WS23 https://www.naldo.de/tickets/semesterticket/
-\newcommand{\semesterticketpreis}{153,10}
+\newcommand{\semesterticketpreis}{161,10}
 % https://www.naldo.de/tickets/dticket-jugendbw-studierende/
-\newcommand{\jugendticketbwpreis}{39,42}
+\newcommand{\jugendticketbwpreis}{45,00}
 % https://www.swtue.de/oepnv/tickets/deutschlandticket-fuer-uebersicht.html
-\newcommand{\detickettuepreis}{58}
+\newcommand{\detickettuepreis}{63,00}
 % discounted ticket for residents of Tübingen and its districts
 % https://www.naldo.de/tickets/deutschlandticket-tuebingen/
-\newcommand{\detickettuebewohnipreis}{49}
+\newcommand{\detickettuebewohnipreis}{54,00}
 
 % Link WS24 https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/studium/studienbeginn/mathematischer-vorbereitungskurs/
 % 3. Mathe Vorkurs
-\newcommand{\matheanmeldung}{27.09.} 		      % Anmeldeschluss (ohne Jahr, mit Punkt am Ende. Bsp.: 31.03.)
-\newcommand{\mathedatum}{Mittwoch, 01. Oktober}     % Beginn (Wochentag, Tag. Monat)
-\newcommand{\mathkontakt}{alfredo.cantarella@uni-tuebingen.de}
+\newcommand{\matheanmeldung}{25.03.} 		      % Anmeldeschluss (ohne Jahr, mit Punkt am Ende. Bsp.: 31.03.)
+\newcommand{\mathedatum}{Montag, 30. März}     % Beginn (Wochentag, Tag. Monat)
+\newcommand{\mathkontakt}{britta.dorn@uni-tuebingen.de}
 
 
 % 4. Anmeldeschluss Informatik Vorkurs für Lebenswissenschaftler (BioInfo Master Variante B ohne Jahr, mit Punkt)
 % Link WS24 https://uni-tuebingen.de/de/215092
 
-\newcommand{\bioinfoAnmeldung}{26.09.}		     % Anmeldeschluss (ohne Jahr, mit Punkt am Ende. Bsp.: 31.03.)
-\newcommand{\bioinfoDatum}{Montag, 06. Oktober} % Beginn (Wochentag, Tag. Monat)
+\newcommand{\bioinfoAnmeldung}{16.03.}		     % Anmeldeschluss (ohne Jahr, mit Punkt am Ende. Bsp.: 31.03.)
+\newcommand{\bioinfoDatum}{Freitag, 27. März} % Beginn (Wochentag, Tag. Monat)
 \newcommand{\bioinfoKontakt}{philipp.thiel@uni-tuebingen.de}
 
 % 5. Anmeldeschluss KogniMaster Mathe Vorkurs 

--- a/src/einleitung.tex
+++ b/src/einleitung.tex
@@ -28,10 +28,10 @@ am besten per E-Mail unter \texttt{fsi\At fsi.uni-tuebingen.de}
 sowie \texttt{kogni-fachschaft\At fsi.uni-tuebingen.de}
 \fi
 erreichen.
-Auf unserer Website \url{www.fsi.uni-tuebingen.de} (oder \url{www.fs-kogni.uni-tuebingen.de}) findest du bereits
+Auf unserer Website \url{www.fsi.uni-tuebingen.de} \ifkogwiss (oder \url{www.fs-kogni.uni-tuebingen.de}) \fi findest du bereits
 jetzt viele hilfreiche Informationen rund ums Studium. Wenn du Lust hast bei der Fachschaft mitzumachen,
 komm einfach zu einer unserer Sitzungen! Alle Sitzungstermine findest du auf unserer Website.
-\ifkogwiss  Informationen zum Psychologie-Teil des Studiums und zu den Veranstaltungen der
+\ifkogwiss Informationen zum Psychologie-Teil des Studiums und zu den Veranstaltungen der
 Fachschaft Psychologie findest du unter \url{www.fs-psycho.uni-tuebingen.de}.\fi
 
 \enlargethispage{3\baselineskip} % we dont want the last line(s) to be put on an extra page
@@ -42,6 +42,6 @@ Deine Fachschaften Kognitionswissenschaft und Informatik
 \else
 Deine Fachschaft Informatik
 \par\hfill
-{\footnotesize Redaktion: Mathis \& Clara}
+{\footnotesize Redaktion: Sebastian - und alle, die vorher dagewesen sind}
 \fi
 \vfill

--- a/src/mailinglisten.tex
+++ b/src/mailinglisten.tex
@@ -21,7 +21,7 @@ Anmeldung unter: \url{https://www.fsi.uni-tuebingen.de/mailman/listinfo/info-tal
 Anmeldung unter: \url{https://www.fsi.uni-tuebingen.de/mailman/listinfo/info-jobs}.
 \item \texttt{coding}: Hackathons und andere Veranstaltungen zum Coden.\\
 Anmeldung unter: \url{https://www.fsi.uni-tuebingen.de/mailman/listinfo/coding}.
-\item \texttt{sport}: Falls ihr zu den *-Informatikern gehört, die entgegen dem Klischee gerne Sport treiben, sei euch die Liste \texttt{sport} ans Herz gelegt.\\
+\item \texttt{sport}: Falls ihr zu den Informatik-Studis gehört, die entgegen dem Klischee gerne Sport treiben, sei euch die Liste \texttt{sport} ans Herz gelegt.\\
 Anmeldung unter: \url{https://www.fsi.uni-tuebingen.de/mailman/listinfo/sport}.
 \end{itemize}
 Falls ihr die Mails filtern wollt (ja, ihr wollt das), solltet ihr den List-Id-Header als Kriterium verwenden: \\

--- a/src/misc.tex
+++ b/src/misc.tex
@@ -1,3 +1,52 @@
+\ifbachelor
+	\fett{Die ersten Vorlesungen}
+	Hier ein kleiner Überblick zu den wichtigsten Vorlesungen:
+	\begin{itemize}
+		\item
+		\textbf{Die Informatik-Vorlesung} \\
+		Die
+		\ifwintersemester \emph{Praktische Informatik 1: Deklarative Programmierung} \fi
+		\ifsommersemester \emph{Praktische Informatik 2: Imperative und objektorientierte Programmierung} \fi
+		ist eine gründliche Einführung in die Entwicklung von Programmen und die dazugehörigen formalen Grundlagen.
+		Du verbringst einen Großteil der Zeit damit, eigene Programme zu schreiben und wirst dabei Schritt für Schritt
+		an Konzepte wie Rekursion oder Abstraktion herangeführt.
+		\ifwintersemester In der Info 1 wird dazu die deklarative Programmiersprache Racket verwendet. \fi
+		\ifsommersemester Die Vorlesung Info 2 ist unabhängig von der Praktischen Informatik 1 und kann auch zu Beginn gehört werden. \fi
+
+		\ifinfo
+			\item
+			\textbf{Technische Informatik} \\
+			\ifwintersemester
+				In \emph{Technische Informatik 1: Digitaltechnik} lernt ihr von den physikalischen Basics, Dioden und Transitoren bis hin zu komplexeren Schaltnetzen alle notwendigen Grundlagen,
+				um die Funktionsweise von Computern zu verstehen. Auch wenn die Informatik oder Mathematik scheinbar wichtiger sind, solltet ihr hier immer am Ball bleiben!
+				Die Vorlesung basiert weitestgehend auf dem Buch \glqq Technische Informatik\grqq \ von Wolfram Schiffmann.
+			\fi
+			\ifsommersemester
+				Die Vorlesung \emph{Technische Informatik 2: Informatik der Systeme} behandelt u.a. folgende sechs Bereiche: Internet, Kodierung, Assemblerprogrammierung, Rechnerarchitektur, Betriebssysteme
+				und Energieversorgung. Sie vermittelt grundlegende Kenntnisse in jedem Bereich und legt einen Schwerpunkt auf die Systemperspektive. Die Technische Informatik 2 ist unabhängig von
+				der Technischen Informatik 1 und kann im ersten Semester gehört werden.
+			\fi
+		\fi
+
+		\item
+		\textbf{Die geliebte Mathematik} \\
+		Die Mathe-Vorlesungen gehören zu den Herausforderungen der ersten Semester und du wirst merken, dass in der Uni-Mathematik ein sehr großer Teil an Selbststudium von dir erwartet wird.
+		Die Vorlesungen orientieren sich an dem Lehrbuch \glqq Mathematik für Informatiker und Bioinformatiker\grqq \ von Prof. Hauck, Prof. Wolff und Prof. Küchlin. Eine gute Möglichkeit zur
+		Einstimmung bietet der \glqq Mathematische Vorbereitungskurs für das Studium der Informatik\grqq  \ (siehe oben).
+		\iflehramt
+			Mathematik-Studierende im Zweitfach brauchen Mathematik 1 nicht besuchen, da dieses Modul durch Analysis 1 abgedeckt wird. 
+			(Weitere Informationen dazu finden sich in der Prüfungsordnung.).
+		\fi
+	\end{itemize}
+\fi
+
+\fett{Die Anfangszeiten und Orte}
+Wie du sicher bald bemerken wirst: 9 Uhr heißt 9:15 Uhr. An der Uni fangen Veranstaltungen in der Regel c.t. (\textit{cum
+tempore}, lat. \glqq mit Zeit\grqq) an. Wenn etwas „pünktlich“ anfängt, wird es als s.t. (\textit{sine tempore}, lat. \glqq ohne
+Zeit\grqq) angekündigt.
+Bezüglich der genauen Zeiten und Orte solltest du vor Vorlesungsbeginn unbedingt Blick in das \hyperlink{alma}{alma}-Portal werfen.
+
+
 \fett{Die wichtigsten Online-Portale}
 Um keine wichtigen Informationen zu verpassen, solltest du dich mit den Online-Lehrportalen der Uni Tübingen vertraut machen
 \footnote{Ja, wir sprechen bewusst in der Mehrzahl, denn wo und wie Lehrmaterialien und Informationen veröffentlicht werden, ist leider immer noch
@@ -19,57 +68,6 @@ von Lehrstuhl zu Lehrstuhl unterschiedlich und man findet sich bei so manchem Mo
 \ifbachelor \ifmedien \pagebreak \fi \fi
 \ifbachelor \ifbinfo \pagebreak \fi \fi
 
-
-\fett{Die Anfangszeiten und Orte}
-Wie du sicher bald bemerken wirst: 9 Uhr heißt 9:15 Uhr. An der Uni fangen Veranstaltungen in der Regel c.t. (\textit{cum
-tempore}, lat. \glqq mit Zeit\grqq) an. Wenn etwas „pünktlich“ anfängt, wird es als s.t. (\textit{sine tempore}, lat. \glqq ohne
-Zeit\grqq) angekündigt.
-Bezüglich der genauen Zeiten und Orte solltest du vor Vorlesungsbeginn unbedingt Blick in das \hyperlink{alma}{alma}-Portal werfen.
-
 % TODO nächstes Semester: Anpassen
 % \ifmaster \pagebreak \fi
 
-\ifbachelor
-\fett{Die ersten Vorlesungen}
-Hier ein kleiner Überblick zu den wichtigsten Vorlesungen:
-\begin{itemize}
-	\item
-	\textbf{Die Informatik-Vorlesung} \\
-	Die
-	\ifwintersemester \emph{Praktische Informatik 1: Deklarative Programmierung} \fi
-	\ifsommersemester \emph{Praktische Informatik 2: Imperative und objektorientierte Programmierung} \fi
-	ist eine gründliche Einführung in die Entwicklung von Programmen und die dazugehörigen formalen Grundlagen.
-	Du verbringst einen Großteil der Zeit damit, eigene Programme zu schreiben und wirst dabei Schritt für Schritt
-	an Konzepte wie Rekursion oder Abstraktion herangeführt.
-	\ifwintersemester In der Info 1 wird dazu die deklarative Programmiersprache Racket verwendet. \fi
-	\ifsommersemester Die Vorlesung Info 2 ist unabhängig von der Praktischen Informatik 1 und kann auch zu Beginn gehört werden. \fi
-	%\fett{Die Informatik-Vorlesung}
-	%Die Vorlesung Informatik 2 ist unabhängig von der Informatik 1 und bietet euch einen Einstieg
-	%in ein vielen noch unbekanntes Thema, die funktionale Programmierung. Im Zentrum stehen dabei Techniken der Abstraktion von Teilproblemen, um den Ablauf komplexerer Programme im Kern zu verstehen und somit Fehler beim Programmieren besser vermeiden zu können.
-
-	\ifinfo
-	\item
-	\textbf{Technische Informatik} \\
-	\ifwintersemester
-	In \emph{Technische Informatik 1: Digitaltechnik} lernt ihr von den physikalischen Basics, Dioden und Transitoren bis hin zu komplexeren Schaltnetzen alle notwendigen Grundlagen,
-	um die Funktionsweise von Computern zu verstehen. Auch wenn die Informatik oder Mathematik scheinbar wichtiger sind, solltet ihr hier immer am Ball bleiben!
-	Die Vorlesung basiert weitestgehend auf dem Buch \glqq Technische Informatik\grqq \ von Wolfram Schiffmann.
-	\fi
-	\ifsommersemester
-	Die Vorlesung \emph{Technische Informatik 2: Informatik der Systeme} behandelt u.a. folgende sechs Bereiche: Internet, Kodierung, Assemblerprogrammierung, Rechnerarchitektur, Betriebssysteme
-	und Energieversorgung. Sie vermittelt grundlegende Kenntnisse in jedem Bereich und legt einen Schwerpunkt auf die Systemperspektive. Die Technische Informatik 2 ist unabhängig von
-	der Technischen Informatik 1 und kann im ersten Semester gehört werden.
-	\fi
-	\fi
-
-	\item
-	\textbf{Die geliebte Mathematik} \\
-	Die Mathe-Vorlesungen gehören zu den Herausforderungen der ersten Semester und du wirst merken, dass in der Uni-Mathematik ein sehr großer Teil an Selbststudium von dir erwartet wird.
-	Die Vorlesungen orientieren sich an dem Lehrbuch „Mathematik für Informatiker und Bioinformatiker“ von Prof. Hauck, Prof. Wolff und Prof. Küchlin. Eine gute Möglichkeit zur
-	Einstimmung bietet der „Mathematische Vorbereitungskurs für das Studium der Informatik“ (siehe oben).
-	\iflehramt
-	Mathematik-Studierende im Zweitfach brauchen Mathematik 1 nicht besuchen, da dieses Modul durch Analysis 1 abgedeckt wird. 
-	(Weitere Informationen dazu finden sich in der Prüfungsordnung.).
-	\fi
-\end{itemize}
-\fi

--- a/src/termine.tex
+++ b/src/termine.tex
@@ -1,5 +1,5 @@
 
-% Roter Kasten mir Corona Disclaimer und anmeldung für events.
+% Roter Kasten: anmeldung für events.
 \setlength{\fboxrule}{4pt}
     \fcolorbox{red}{white}{
         \begin{minipage}[t]{\textwidth}
@@ -17,7 +17,7 @@
                 \textbf{Bitte melde dich zu allen Veranstaltungen an}, außer es steht explizit dabei, dass keine Anmeldung notwendig ist.
                 Die Anmeldung ist in der Regel ab einer Woche vor der jeweiligen Veranstaltung möglich.\\
                 Falls du dich zu einer Veranstaltung angemeldet hast und doch nicht kommen wirst, dann melde dich bitte auch wieder ab.
-                Weitere Details und die Anmeldung zur jeweiligen Veranstaltung  findest du auch immer auf \url{https://eei.fsi.uni-tuebingen.de}.
+                Weitere Details und die Anmeldung zur jeweiligen Veranstaltung  findest du auch immer auf ~\url{https://eei.fsi.uni-tuebingen.de}.
             \fi
         \end{minipage}}
 \begin{description}
@@ -93,138 +93,165 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Ab hier die FSI Events einfügen. Darüber sind der Mathe und Info vorkurs.
 
-%Spieleabend 1
-\ifml
-    \item[Board Game Night 1 -- Wednesday, October 1st \YEAR, Sand]~\\%, 19:00, Sand]~\\
-    We'd like to invite you to a board game night in relaxed atmosphere at the Sand.
-    We'll provide some games as well as drinks and snacks (for a small donation).
-    Even though our collection is growing steadily, we're more than happy if you bring along your own games!\\
-    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
-\else
-    \item[Spieleabend 1 -- Mittwoch, 1. Oktober \YEAR, Sand]~\\%, 19:00 Uhr, Sand]~\\
-    Wir möchten dich zu einem kleinen Analog-Spieleabend mit guter Gesellschaft und entspannter Atmosphäre auf dem Sand einladen.
-    Für einige Spiele sowie Getränke und Knabberkram (gegen einen kleinen Obolus) sorgt die Fachschaft.
-    Wir freuen uns natürlich sehr, wenn du auch eigene Spiele mitbringst, obwohl unsere Sammlung schon beachtlich ist!\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
-\fi
-
-% Kneipentour 1 % TODO Uhrzeit
-\ifml
-    \item[Pub Crawl 1 -- Tuesday, October 7th \YEAR]~\\
-    Tübingen is a town full of small pubs and bars that characterize the nightlife.
-    To calm down from the stress of this information-filled day, we'd like to invite you to go bar-hopping with us.
-    We'll divide up into small groups and visit the different bars in the historic town center.
-    Please bring enough cash, most places we will visit don't accept cards (\emph{none whatsoever}).
-\else
-    \item[Kneipentour 1 -- Dienstag, 7. Oktober \YEAR]~\\
-    Tübingen ist übersät mit kleinen Kneipen und Bars, die das Nachtleben maßgeblich bestimmen.
-    Um den Stress der ersten Veranstaltungen etwas sacken zu lassen, laden wir dich zu einer ausgiebigen Kneipentour ein,
-    bei der wir in Kleingruppen die verschiedenen Lokalitäten der Tübinger Altstadt besuchen.
-    Bitte bringe genügend Bargeld mit, man kann in fast keiner der Tübinger Bars mit EC-Karte zahlen! -- Volksbanken und Sparkassen finden sich bei Bedarf in der Stadt.
-\fi
-
-%Mastercafé
-\ifmaster
-    \ifml
-        \item[Mastercafé -- Thursday, October 9th \YEAR, 14:30, Sand, A301/A302]\ \\
-        At this informal meeting you will have the opportunity to get to know your fellow students and some of the lecturers over a coffee. And then there will be cake.\footnote{This is not a lie!}\\
-        % \seticon{faBus}~\textbf{bus stop:} route 3, "`Maria-von-Linden-Straße"' (signposted from there)
-        \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
-   \else
-        \item[Mastercafé -- Donnerstag, 9. Oktober \YEAR, 14:30 Uhr, Sand, A301/A302]\ \\
-        Bei diesem informellen Treffen hast du Gelegenheit, neue Master-Studierende aus deinem eigenen und auch aus anderen Studiengängen sowie einige der Dozierenden bei Kaffee kennenzulernen. Und dann gibt es Kuchen.\footnote{Das ist keine Lüge!}\\
-        \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
-   \fi
-\fi
-
-% Nur damit die Seite richtig gebrochen wird.
-% TODO: Muss jedes jahr angepasst werden.
-\ifmaster \ifinfo \iflehramt \else \pagebreak \fi \fi \fi
-\ifmaster \ifmedien \pagebreak \fi \fi
-\ifmaster \ifmedinfo \pagebreak \fi \fi
-\ifmaster \ifkogwiss \pagebreak \fi \fi
-
-% Facheinführung
-\ifml
-    \item[Subject Introduction -- Thursday, October 9th to Friday, October 10th \YEAR]\ \\ 
-    Subject Introduction where you will receive important information about your course of study. You can find the date for your subject at \url{https://uni-tuebingen.de/de/197597}.
-    We recommend attending to make the start of your studies easier.
-\else    
-    \item[Facheinführung -- Donnerstag, 09. Oktober bis Freitag, 10. Oktober \YEAR]\ \\ 
-    Fächerspezifische Einführungsveranstaltung, in der du wichtige Informationen zum Studienverlauf erhältst. Den Termin für dein Fach findest du am besten auf \url{https://uni-tuebingen.de/de/197597}.
-    Wir empfehlen dir die Teilnahme, um deinen Studienstart zu erleichtern.
-\fi
-
-% Frühstück
-\ifbachelor
-    \item[Frühstück -- Freitag, 10. Oktober \YEAR, 10:00 Uhr, Mensa Morgenstelle]\ \\
-    Wir laden dich an diesem Morgen zu einem gemütlichen Frühstück ein! Dabei erfährst du einiges über die Uni, die Fachschaft und was dich in den nächsten Monaten erwartet -- auch im Gespräch mit älteren Studierenden.
-    Danach machen wir eine Führung über die Morgenstelle, damit du die wichtigsten Räume und Hörsäle kennenlernst.
-    Wenn du Lust hast, kannst du anschließend ab 11:45 Uhr das Mensaessen ausprobieren.\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} BG Unfallklinik (Linien 5, 13, 14, 17, 18, 19, X15)
-\fi
-
-\ifbachelor \pagebreak \fi
-
-% Semestereröffnung
-\ifml
-    \vspace{-2.07182\baselineskip} \ \\ % to counteract the different spacing of the parbox in the line below. Remove this line if you remove the parbox and vspace in the line below
-    \item[\parbox{\linewidth}{Semester Opening by Faculty -- Friday, October 10th \YEAR, 16:15,\\ EG, Maria-von-Linden-Str.1}]\ \vspace{.355\baselineskip} \\ % parbox and vspace since the line is too long
-    This department information event with presentation of all elective courses in the winter
-    semester is especially useful if you are new to Tübingen and want to get a first impression
-    of the professors and courses you will be dealing with in the future.\\
-    \seticon{faBus}~\textbf{bus stop:} Sternwarte (bus line 3)
-\else
-    \vspace{-2.07182\baselineskip} \ \\ % to counteract the different spacing of the parbox in the line below. Remove this line if you remove the parbox and vspace in the line below
-    \item[\parbox{\linewidth}{Semestereröffnung Fachbereich -- Freitag, 10. Oktober \YEAR, 16:15 Uhr,\\ EG Maria-von-Linden-Str.1}]\ \vspace{.355\baselineskip} \\ % parbox and vspace since the line is too long
-    Informationsveranstaltung des Fachbereichs mit Vorstellung aller
-    Wahlveranstaltungen im Wintersemester.
-    \ifbachelor
-        Die Veranstaltung richtet sich vor allem an höhere Semester,
-        wer als hochmotivierter Bachelor-Ersti Informationen sammeln will, darf natürlich dennoch vorbeischauen.
-    \else
-        Diese Veranstaltung ist besonders sinnvoll, wenn du neu nach Tübingen kommst um dir ein erstes Bild davon zu machen,
-        mit welchen Professoren und Veranstaltungen du es zukünftig zu tun hast.
-    \fi
-    \seticon{faBus}~\textbf{Bushaltestelle:} Sternwarte (Linie 3)
-\fi
-
 % Grillen 1
 \ifml
-    \item[BBQ 1 -- Friday, October 10th \YEAR, 18:30, in the garden of the Sand]~\\
+    \item[BBQ 1 -- Tuesday, March 31th \YEAR, 18:30, in the garden of the Sand]~\\
     You're not in the mood for cooking this evening? Fear not!
     The student council invites you for a BBQ. Bring whatever you want to put on the grill,
     please also bring your own plates and cutlery. The garden has enough space for stuff like volleyball, football etc. as well.\\
     \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
 \else
-    \item[Grillen 1 -- Freitag, 10. Oktober \YEAR, 18:30 Uhr, im Garten des Sandes]~\\
+    \item[Grillen 1 -- Dienstag, 31. März \YEAR, 18:30 Uhr, im Garten des Sandes]~\\
     Du hast keinen Bock auf Kochen? Dann bist du hier genau richtig! In geselliger Runde wird die Fachschaft mit dir grillen.
     Bring dazu mit, was auch immer du zum Grillen brauchst, ein großer Gasgrill wartet auf dich. Vergiss bitte auch nicht, dein eigenes Besteck und Geschirr einzupacken!\\
     Auf dem Sand ist es auch möglich Volleyball, Fußball, usw. zu spielen. Wir freuen uns auf dich!\\
     \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
 \fi
 
+%WENN Bioinfo-Master
+\ifmaster
+    \ifbinfo
+        \pagebreak
+    \fi
+\fi
+
+%Spieleabend 1
+\ifml
+    \item[Board Game Night 1 -- Wednesday, April 1st \YEAR, Sand]~\\%, 19:00, Sand]~\\
+    We'd like to invite you to a board game night in relaxed atmosphere at the Sand.
+    We'll provide some games as well as drinks and snacks (for a small donation).
+    Even though our collection is growing steadily, we're more than happy if you bring along your own games!\\
+    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
+\else
+    \item[Spieleabend 1 -- Mittwoch, 1. April \YEAR, Sand]~\\%, 19:00 Uhr, Sand]~\\
+    Wir möchten dich zu einem kleinen Analog-Spieleabend mit guter Gesellschaft und entspannter Atmosphäre auf dem Sand einladen.
+    Für einige Spiele sowie Getränke und Knabberkram (gegen einen kleinen Obolus) sorgt die Fachschaft.
+    Wir freuen uns natürlich sehr, wenn du auch eigene Spiele mitbringst, obwohl unsere Sammlung schon beachtlich ist!\\
+    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+\fi
+
+%Mastercafé
+\ifmaster
+    \ifml
+        \item[Mastercafé -- Thursday, April 9th \YEAR, 14:30, MvL1, 6th floor]\ \\
+        At this informal meeting you will have the opportunity to get to know your fellow students and some 
+        of the lecturers over a coffee. And then there will be cake.\footnote{This is not a lie!}\\
+        % \seticon{faBus}~\textbf{bus stop:} route 3, "`Maria-von-Linden-Straße"' (signposted from there)
+        \seticon{faBus}~\textbf{bus stop:} Sternwarte (bus line 3)
+   \else
+        \item[Mastercafé -- Donnerstag, 9. April \YEAR, 14:30 Uhr, MvL1, Etage 6]\ \\
+        Bei diesem informellen Treffen hast du Gelegenheit, neue Master-Studierende aus deinem eigenen 
+        und auch aus anderen Studiengängen sowie einige der Dozierenden bei Kaffee kennenzulernen. Und dann gibt es Kuchen.
+        \footnote{Das ist keine Lüge!}\\
+        \seticon{faBus}~\textbf{Bushaltestelle:} Sternwarte (Linie 3)
+   \fi
+\fi
+
+%WENN Master ABER NICHT Bioinformatik
+\ifmaster
+    \ifbinfo
+        \else
+        \pagebreak
+    \fi
+\fi
+
+% Frühstück
+\ifml
+    \item[Breakfast -- Friday, April 10th \YEAR, 10:00, Sand]\ \\
+    We invite you to a cozy breakfast this morning! During this time, you'll learn a lot 
+    about the university, the student council, and what to expect in the coming months—also 
+    through conversations with senior students. Right after, you can attend the official introductory event 
+    for first-year students in the Department of Computer Science. We've set aside enough time for this.
+    To plan better and reserve spots, we kindly ask you to let us know if you're coming. \\
+    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
+\else
+    \item[Frühstück -- Freitag, 10. April \YEAR, 10:00 Uhr, Mensa Morgenstelle]\ \\
+    Wir laden dich an diesem Morgen zu einem gemütlichen Frühstück ein! 
+    Dabei erfährst du einiges über die Uni, die Fachschaft und was dich in den nächsten Monaten 
+    erwartet – auch im Gespräch mit älteren Studierenden. Direkt im Anschluss kannst du dann noch 
+    zur offizielle Erstsemesterbegrüßung des Fachbereichs Informatik. Wir haben extra genug Zeit eingeplant.
+    Um besser planen und Plätze reservieren zu können, bitten wir euch Bescheid zu geben, wenn ihr kommt. \\
+    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+\fi
+
+\ifbachelor
+    \pagebreak
+\fi
+
+% Facheinführung
+\ifml
+    \item[Subject Introduction -- TBA]\ \\ 
+    Subject Introduction where you will receive important information about your course of study. You can find the date for your subject at \url{https://uni-tuebingen.de/de/197597}.
+    We recommend attending to make the start of your studies easier.
+\else    
+    \item[Facheinführung -- TBA]\ \\ 
+    Fächerspezifische Einführungsveranstaltung, in der du wichtige Informationen zum Studienverlauf erhältst. Den Termin für dein Fach findest du am besten auf \url{https://uni-tuebingen.de/de/197597}.
+    Wir empfehlen dir die Teilnahme, um deinen Studienstart zu erleichtern.
+\fi
+
+% Semestereröffnung
+\ifml
+    \vspace{-2.07182\baselineskip} \ \\ % to counteract the different spacing of the parbox in the line below. Remove this line if you remove the parbox and vspace in the line below
+    \item[\parbox{\linewidth}{Semester Opening by Faculty -- Friday, April 10th \YEAR, 16:00, EG, MvL1}]\ \vspace{.355\baselineskip} \\ % parbox and vspace since the line is too long
+    This department information event with presentation of all elective courses in the summer
+    semester is especially useful if you are new to Tübingen and want to get a first impression
+    of the professors and courses you will be dealing with in the future.\\
+    \seticon{faBus}~\textbf{bus stop:} Sternwarte (bus line 3)
+\else
+    \vspace{-2.07182\baselineskip} \ \\ % to counteract the different spacing of the parbox in the line below. Remove this line if you remove the parbox and vspace in the line below
+    \item[\parbox{\linewidth}{Semestereröffnung Fachbereich -- Freitag, 10. April \YEAR, 16:00 Uhr, EG MvL1}]\ \vspace{.355\baselineskip} \\ % parbox and vspace since the line is too long
+    Informationsveranstaltung des Fachbereichs mit Vorstellung aller
+    Wahlveranstaltungen im Sommersemester.
+    \ifbachelor
+        Die Veranstaltung richtet sich vor allem an höhere Semester,
+        wer als hochmotivierter Bachelor-Ersti Informationen sammeln will, darf natürlich dennoch vorbeischauen.
+    \else
+        Diese Veranstaltung ist besonders sinnvoll, wenn du neu nach Tübingen kommst um dir ein erstes Bild davon zu machen,
+        mit welchen Professoren und Veranstaltungen du es zukünftig zu tun hast.
+    \fi \\
+    \seticon{faBus}~\textbf{Bushaltestelle:} Sternwarte (Linie 3)
+\fi
+
+% Grillen 2
+\ifml
+    \item[BBQ 2 -- Friday, April 10th \YEAR, 18:30, in the garden of the Sand]~\\
+    Because it's so nice, we'll have another barbecue!
+    Bring whatever you'd like to grill, and don’t forget your own plates and cutlery!\\
+    You can also play volleyball, football, and more in the garden. We’re looking forward to seeing you there!\\
+    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
+\else
+    \item[Grillen 2 -- Freitag, 10. April \YEAR, 18:30 Uhr, im Garten des Sandes]~\\
+    Und weils so schön ist, grillen wir nochmal!
+    Bring mit, was auch immer du grillen möchtest. Eigenes Besteck und Geschirr bitte nicht vergessen!\\
+    Auf dem Sand ist es auch möglich Volleyball, Fußball, usw. zu spielen. Wir freuen uns auf dich!\\
+    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+\fi
+
 %Wanderung 1
 \ifml
-	\item[Hike 1 -- Saturday, October 11th \YEAR, 10:30, on the Neckarinsel (Neckar Island)]~\\
+	\item[Hike 1 -- Saturday, April 11th \YEAR, 10:30, on the Neckarinsel (Neckar Island)]~\\
 	On a leisurely hike you will get to know not only your fellow students,
 	but also a few lecturers and the worthwhile surroundings of Tübingen!
-	% The meeting point is at the Neckarbrücke \emph{in front of the} restaurant \glqq Neckarmüller\grqq.\\
 	The meeting point is on the Neckarinsel.\\
 	\seticon{faBus}~\textbf{bus stop:} Neckarbrücke (lines 1--22)
 \else
-	\item[Wanderung 1 -- Samstag, 11. Oktober \YEAR, 10:30 Uhr, auf der Neckarinsel]~\\
+	\item[Wanderung 1 -- Samstag, 11. April \YEAR, 10:30 Uhr, auf der Neckarinsel]~\\
 	Bei einer gemütlichen Wanderung lernt ihr neben euren Kommilitonen und Kommilitoninnen auch
 	noch ein paar Dozierende und die sehenswerte Tübinger Umgebung kennen!
-	% Der Treffpunkt ist bei der Neckarbrücke (\emph{vor} dem Gasthaus \glqq Neckarmüller\grqq).\\
 	Der Treffpunkt ist auf der Neckarinsel.\\
 	\seticon{faBus}~\textbf{Bushaltestelle:} Neckarbrücke (Linien 1--22)
 \fi
 
+%WENN Bioinfo-Master
+\ifmaster
+    \ifbinfo
+        \pagebreak
+    \fi
+\fi
 
 % Erste Vorlesung
 \ifbachelor
-    \item[Erste Vorlesung -- Montag, 13. Oktober \YEAR, \ifwintersemester 8:00 Uhr, \else 10:00 Uhr, \fi Morgenstelle]~\\
+    \item[Erste Vorlesung -- Montag, 13. April \YEAR, \ifwintersemester 8:00 Uhr, \else 10:00 Uhr, \fi Morgenstelle]~\\
     Deine erste Vorlesung beginnt um
     \ifwintersemester 8:00 Uhr -- Du hast „Mathematik für Informatik 1“  \fi
     \ifsommersemester 10:00 Uhr -- Du hast „Mathematik für Informatik 2“  \fi
@@ -233,68 +260,167 @@
     \seticon{faBus}~\textbf{Bushaltestelle:} BG Unfallklinik (Linien 5, 13, 14, 17, 18, 19, X15)
 \fi
 
-% Filmeabends % TODO date & time % TODO invite ML, movie language?
-\ifml
-    \item[Movie Night -- Tuesday, October 14th \YEAR, 19:15 Uhr, HS24 Kupferbau]~\\%, 19:00, Sand]~\\
-    % Falls im Wintersemester ein Filmeabend veranstaltet wird, sollte in der Einladung erwähnt werden, auf welcher
-    % Sprache der Film gezeigt wird.
-    In the evening, we're hosting a movie night, and we'd love for you to join us!
-    It'll be a great way to unwind after your first days of student life.
-    Bring your new friends, your favorite snacks and drinks, and let's go!\\
-    \seticon{faBus}~\textbf{bus stop:}  Hölderlinstraße, Uni/Neue Aula 
-\else
-    \item[Filmeabend -- Dienstag, 14. Oktober \YEAR, 19:15 Uhr, HS24 Kupferbau]~\\
-    Am Abend veranstalten wir unseren Filmeabend und wir laden euch herzlich dazu ein!\\
-    Schaut mit uns einen Film an und entspannt euch nach euren ersten Tagen im Studileben.
-    Bringt eure neuen Freunde, Freundinnen, eure Lieblingssnacks \& -drinks mit und los geht's!\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Hölderlinstraße, Uni/Neue Aula
-\fi
-
 %Spieleabend 2 %TODO time
 \ifml
-	\item[Board Game Night 2 -- Wednesday, October 15th \YEAR, Sand]~\\%, 19:00, Sand]~\\
+	\item[Board Game Night 2 -- Tuesday, April 14th \YEAR, Sand]~\\%, 19:00, Sand]~\\
 	We'd like to invite you to a board game night in relaxed atmosphere at the Sand.
 	We'll provide some games as well as drinks and snacks (for a small donation).
 	Even though our collection is growing steadily, we're more than happy if you bring along your own games!\\
 	\seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
 \else
-	\item[Spieleabend 2 -- Mittwoch, 15. Oktober \YEAR, Sand]~\\%, 19:00 Uhr, Sand]~\\
+	\item[Spieleabend 2 -- Dienstag, 14. April \YEAR, Sand]~\\%, 19:00 Uhr, Sand]~\\
 	Wir möchten dich zu einem kleinen Analog-Spieleabend mit guter Gesellschaft und entspannter Atmosphäre auf dem Sand einladen.
 	Für einige Spiele sowie Getränke und Knabberkram (gegen einen kleinen Obolus) sorgt die Fachschaft.
 	Wir freuen uns natürlich sehr, wenn du auch eigene Spiele mitbringst, obwohl unsere Sammlung schon beachtlich ist!\\
 	\seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
 \fi
 
-% Kogni Info Abend
-\ifkogwiss
-	\item[Kogni-FAQ-Abend -- Donnerstag, 16. Oktober \YEAR, Sand]~\\%, 18:30 Uhr, Sand
-	Falls ihr noch offene Fragen über das Studium oder zur (oftmals unübersichtlichen) Organisation habt, 
-    könnt ihr diese hier andere Studierende stellen. Außerdem geben wir ein paar Tipps, die wir gerne auch als Ersti gehört hätten.
-    Natürlich könnt ihr auch einfach zum Zuhören dazu kommen.\\
-	\seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+% Kneipentour 1
+\ifml
+    \item[Pub Crawl -- Friday, April 17th \YEAR]~\\
+    Tübingen is a town full of small pubs and bars that characterize the nightlife.
+    To calm down from the stress of this information-filled day, we'd like to invite you to go bar-hopping with us.
+    We'll divide up into small groups and visit the different bars in the historic town center.
+    Please bring enough cash, most places we will visit don't accept cards. \\
+    Registration is mandatory here -- only then will you receive the meeting point of your group via email.
+\else
+    \item[Kneipentour -- Freitag, 17. April \YEAR]~\\
+    Tübingen ist übersät mit kleinen Kneipen und Bars, die das Nachtleben maßgeblich bestimmen.
+    Um den Stress der ersten Veranstaltungen etwas sacken zu lassen, laden wir dich zu einer ausgiebigen Kneipentour ein,
+    bei der wir in Kleingruppen die verschiedenen Lokalitäten der Tübinger Altstadt besuchen.
+    Bitte bringe genügend Bargeld mit, man kann in fast keiner der Tübinger Bars mit EC-Karte zahlen! -- Volksbanken und Sparkassen finden sich bei Bedarf in der Stadt. \\
+    \textbf{Anmeldung} ist hier Pflicht - nur dann erhältst du per Mail passend den Treffpunkt deiner Gruppe mitgeteilt.
 \fi
 
-\ifmaster \ifkogwiss \pagebreak \fi \fi
-
-% Kneipentour 2 % TODO Uhrzeit
-\ifml
-	\item[Pub Crawl 2 -- Friday, October 17th \YEAR]~\\
-	Ready for round two? Join us for another pub crawl through Tübingen's best spots.
-	We'll split into smaller groups again and visit the different bars in the historic town center.
-	Please bring enough cash, most places we will visit don't accept cards (\emph{none whatsoever}).
+%WENN NICHT Bioinfo-Master
+\ifmaster
+    \ifbinfo
+    \else
+        \pagebreak
+    \fi
 \else
-	\item[Kneipentour 2 -- Freitag, 17. Oktober \YEAR]~\\
-	Bereit für Runde Zwei? Komm mit auf eine weitere Kneipentour durch die besten Kneipen Tübingens.
-	Wir werden uns wieder in kleinere Gruppen aufteilen und die verschiedenen Bars in der Altstadt besuchen.
-	Bitte bringe genügend Bargeld mit, man kann in fast keiner der Tübinger Bars mit EC-Karte zahlen! -- Volksbanken und Sparkassen 	finden sich bei Bedarf in der Stadt.
+    \pagebreak
+\fi
+
+%Wanderung 2
+\ifml
+	\item[Hike 2 -- Sunday, April 19th \YEAR, 10:30, on the Neckarinsel (Neckar Island)]~\\
+	Time for another hike! Join us for a relaxing stroll through the beautiful Tübingen countryside.
+	This is a great chance to enjoy nature, chat with fellow students, and maybe even meet some of your professors.
+	% The meeting point is at the Neckarbrücke \emph{in front of the} restaurant \glqq Neckarmüller\grqq.\\
+	The meeting point is on the Neckarinsel.\\
+	\seticon{faBus}~\textbf{bus stop:} Neckarbrücke (lines 1--22)
+\else
+	\item[Wanderung 2 -- Sonntag, 19. April \YEAR, 10:30 Uhr, auf der Neckarinsel]~\\
+	Zeit für eine weitere Wanderung! Komm mit auf einen entspannten Spaziergang durch die schöne Umgebung Tübingens.
+	Bei einer gemütlichen Wanderung lernt ihr eure Kommilitonen und Kommilitoninnen
+	und vielleicht auch ein paar Dozierende kennen!
+	% Der Treffpunkt ist bei der Neckarbrücke (\emph{vor} dem Gasthaus \glqq Neckarmüller\grqq).\\
+	Der Treffpunkt ist auf der Neckarinsel.\\
+	\seticon{faBus}~\textbf{Bushaltestelle:} Neckarbrücke (Linien 1--22)
+\fi
+
+
+%Clubhausfest
+\ifml
+    \item[Clubhausfest -- Thursday, April 30th \YEAR, 21:00, Clubhaus]\ \\
+    Every thursday during the lecture period, a different student body or group of students organizes the "`Clubhaus Fest"' in
+    the Clubhaus, which locates directly opposite of the new auditorium. Today the attendance is particularly worthwhile, because
+    the student councils of computer science, cognitive science and psychology are hosting the event! \\
+    No registration necessary.\\
+    \seticon{faBus}~\textbf{bus stop:} Uni/Neue Aula or Hölderlinstraße
+\else
+    \item[Clubhausfest -- Donnerstag, 30. April \YEAR, 21:00 Uhr, Clubhaus]\ \\
+    Während der Vorlesungszeit richtet jeden Donnerstag eine andere Fachschaft oder studentische Gruppierung das Clubhausfest
+    im Clubhaus, direkt gegenüber der Neuen Aula, aus. Heute lohnt sich der Besuch jedoch ganz besonders, denn die Fachschaften
+    Informatik, Kogni und Psychologie sind Gastgeber!\\ % \\ % TODO line break wieder einfügen: Eigentlich wäre hier ein line break schöner, aber im WS24 würde dann eine einzelne Zeile auf die nächste Seite kommen
+    Keine Anmeldung nötig.\\
+    %Das anfängliche Chaos des Vorlesungsbeginns hat sich gelegt und auch an diesem Donnerstag findet das Clubhausfest statt.\\
+    \seticon{faBus}~\textbf{Bushaltestelle:} Uni/Neue Aula oder Hölderlinstraße
+\fi
+
+
+%Schnuppersitzung % TODO date & time
+\ifkogwiss
+    \vspace{-2.07182\baselineskip} \ \\ % to counteract the different spacing of the parbox in the line below. Remove this line if you remove the parbox and vspace in the line below
+     \item[\parbox{\linewidth}{Schnuppersitzung der fsk -- Donnerstag, 20. November \YEAR, 18:30 \\ 
+        (reguläre Sitzungen: Donnerstags, 18:30, vor dem Kogni Zimmer), Sand}]\ \vspace{.355\baselineskip} \\
+        Hoffentlich konnten wir mit unseren Veranstaltungen euer Interesse an Fachschaftsarbeit wecken.
+        Wir machen aber noch viel mehr als nur Ersti-Veranstaltungen, wir vertreten die Studierenden in Gremien,
+        sind Ansprechpartner, stellen Infrastruktur und Tools bereit und vieles mehr.
+     Komm doch einfach mal zu unserer Schnuppersitzung
+     \footnote{Natürlich freuen wir uns auch sehr, wenn du sogar schon vor der Schnuppersitzung zu regulären Sitzungen kommst :)}
+        und schau ob es dir gefällt!\\
+        Keine Anmeldung nötig.\\
+        \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+\else
+        \item[Schnuppersitzung der \textit{fsi} -- Donnerstag, 19. April \YEAR, 18:30 Uhr, Sand]\ \\ 
+        Hoffentlich konnten wir mit unseren Veranstaltungen euer Interesse an Fachschaftsarbeit wecken.
+        Wir machen aber noch viel mehr als nur Ersti-Veranstaltungen, wir vertreten die Studierenden in Gremien,
+        sind Ansprechpartner, stellen Infrastruktur und Tools bereit und vieles mehr.
+        Komm doch einfach mal zu unserer Schnuppersitzung\footnote{Natürlich freuen wir uns auch sehr, wenn du sogar schon vor der Schnuppersitzung zu regulären Sitzungen kommst :)}
+        und schau ob es dir gefällt!\\
+        Keine Anmeldung nötig.\\
+        \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
 \fi
 
 % Nur damit die Seite richtig gebrochen wird.
 % TODO: Muss jedes jahr angepasst werden.
-\ifkogwiss
-\else
-    \ifbachelor \pagebreak \fi
-\fi
+% \ifmaster \ifinfo \iflehramt \else \pagebreak \fi \fi \fi
+% \ifmaster \ifmedien \pagebreak \fi \fi
+% \ifmaster \ifmedinfo \pagebreak \fi \fi
+% \ifmaster \ifkogwiss \pagebreak \fi \fi
+
+% \ifbachelor \pagebreak \fi
+
+
+% Filmeabends % TODO date & time % TODO invite ML, movie language?
+% \ifml
+%     \item[Movie Night -- Tuesday, October 14th \YEAR, 19:15 Uhr, HS24 Kupferbau]~\\%, 19:00, Sand]~\\
+%     % Falls im Wintersemester ein Filmeabend veranstaltet wird, sollte in der Einladung erwähnt werden, auf welcher
+%     % Sprache der Film gezeigt wird.
+%     In the evening, we're hosting a movie night, and we'd love for you to join us!
+%     It'll be a great way to unwind after your first days of student life.
+%     Bring your new friends, your favorite snacks and drinks, and let's go!\\
+%     \seticon{faBus}~\textbf{bus stop:}  Hölderlinstraße, Uni/Neue Aula 
+% \else
+%     \item[Filmeabend -- Dienstag, 14. Oktober \YEAR, 19:15 Uhr, HS24 Kupferbau]~\\
+%     Am Abend veranstalten wir unseren Filmeabend und wir laden euch herzlich dazu ein!\\
+%     Schaut mit uns einen Film an und entspannt euch nach euren ersten Tagen im Studileben.
+%     Bringt eure neuen Freunde, Freundinnen, eure Lieblingssnacks \& -drinks mit und los geht's!\\
+%     \seticon{faBus}~\textbf{Bushaltestelle:} Hölderlinstraße, Uni/Neue Aula
+% \fi
+
+% Kogni Info Abend
+% \ifkogwiss
+% 	\item[Kogni-FAQ-Abend -- Donnerstag, 16. Oktober \YEAR, Sand]~\\%, 18:30 Uhr, Sand
+% 	Falls ihr noch offene Fragen über das Studium oder zur (oftmals unübersichtlichen) Organisation habt, 
+%     könnt ihr diese hier andere Studierende stellen. Außerdem geben wir ein paar Tipps, die wir gerne auch als Ersti gehört hätten.
+%     Natürlich könnt ihr auch einfach zum Zuhören dazu kommen.\\
+% 	\seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+% \fi
+
+% \ifmaster \ifkogwiss \pagebreak \fi \fi
+
+% Kneipentour 2 % TODO Uhrzeit
+% \ifml
+% 	\item[Pub Crawl 2 -- Friday, October 17th \YEAR]~\\
+% 	Ready for round two? Join us for another pub crawl through Tübingen's best spots.
+% 	We'll split into smaller groups again and visit the different bars in the historic town center.
+% 	Please bring enough cash, most places we will visit don't accept cards (\emph{none whatsoever}).
+% \else
+% 	\item[Kneipentour 2 -- Freitag, 17. Oktober \YEAR]~\\
+% 	Bereit für Runde Zwei? Komm mit auf eine weitere Kneipentour durch die besten Kneipen Tübingens.
+% 	Wir werden uns wieder in kleinere Gruppen aufteilen und die verschiedenen Bars in der Altstadt besuchen.
+% 	Bitte bringe genügend Bargeld mit, man kann in fast keiner der Tübinger Bars mit EC-Karte zahlen! -- Volksbanken und Sparkassen 	finden sich bei Bedarf in der Stadt.
+% \fi
+
+% Nur damit die Seite richtig gebrochen wird.
+% TODO: Muss jedes jahr angepasst werden.
+% \ifkogwiss
+% \else
+%     \ifbachelor \pagebreak \fi
+% \fi
 % \ifmaster \ifinfo \iflehramt \else \pagebreak \fi \fi \fi
 % \ifmaster \ifmedien \pagebreak \fi \fi
 % \ifmaster \ifmedinfo \pagebreak \fi \fi
@@ -338,35 +464,20 @@
 % TODO: Muss jedes jahr angepasst werden.
 % \ifmaster \ifbinfo \else \ifml \else \pagebreak \fi \fi \fi
 
-% Grillen 2
-\ifml
-    \item[BBQ 2 -- Saturday, October 18th \YEAR, 18:30, in the garden of the Sand]~\\
-    Because it's so nice, we'll have another barbecue!
-    Bring whatever you'd like to grill, and don’t forget your own plates and cutlery!\\
-    You can also play volleyball, football, and more in the garden. We’re looking forward to seeing you there!\\
-    \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
-\else
-    \item[Grillen 2 -- Samstag, 18. Oktober \YEAR, 18:30 Uhr, im Garten des Sandes]~\\
-    Und weils so schön ist, grillen wir nochmal!
-    Bring mit, was auch immer du grillen möchtest. Eigenes Besteck und Geschirr bitte nicht vergessen!\\
-    Auf dem Sand ist es auch möglich Volleyball, Fußball, usw. zu spielen. Wir freuen uns auf dich!\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
-\fi
-
 %Flunkyball
-\ifml
-	\item[Flunkyball -- Tuesday, October 21st \YEAR, Sand]~\\
-	Fancy a round of flunkyball? Come along, grab a bottle and have fun!
-	Perfect opportunity to switch off and meet new people.
-	Teams can be formed spontaneously and you can get beer from us for a small donation.\\
-	\seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
-\else
-	\item[Flunkyball -- Dienstag, 21. Oktober \YEAR, Sand]~\\
-	Lust auf 'ne Runde Flunkyball? Komm vorbei, schnapp dir 'ne Flasche und hab Spaß!
-	Perfekte Gelegenheit, um abzuschalten und neue Leute kennenzulernen.
-	Teams können spontan gebildet werden und Bier kannst du von uns gegen eine kleine Spende bekommen.\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
-\fi
+% \ifml
+% 	\item[Flunkyball -- Tuesday, October 21st \YEAR, Sand]~\\
+% 	Fancy a round of flunkyball? Come along, grab a bottle and have fun!
+% 	Perfect opportunity to switch off and meet new people.
+% 	Teams can be formed spontaneously and you can get beer from us for a small donation.\\
+% 	\seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
+% \else
+% 	\item[Flunkyball -- Dienstag, 21. Oktober \YEAR, Sand]~\\
+% 	Lust auf 'ne Runde Flunkyball? Komm vorbei, schnapp dir 'ne Flasche und hab Spaß!
+% 	Perfekte Gelegenheit, um abzuschalten und neue Leute kennenzulernen.
+% 	Teams können spontan gebildet werden und Bier kannst du von uns gegen eine kleine Spende bekommen.\\
+%     \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
+% \fi
 
 % % Capture the Flag
 % \ifml
@@ -382,89 +493,18 @@
 % \fi
 
 
-%Clubhausfest
-\ifml
-    \item[Clubhausfest -- Thursday, October 23rd \YEAR, 21:00, Clubhaus]\ \\
-    Every thursday during the lecture period, a different student body or group of students organizes the "`Clubhaus Fest"' in
-    the Clubhaus, which locates directly opposite of the new auditorium. Today the attendance is particularly worthwhile, because
-    the student councils of computer science, cognitive science and psychology are hosting the event! \\
-    No registration necessary.\\
-    \seticon{faBus}~\textbf{bus stop:} Uni/Neue Aula or Hölderlinstraße
-\else
-    \item[Clubhausfest -- Donnerstag, 23. Oktober \YEAR, 21:00 Uhr, Clubhaus]\ \\
-    Während der Vorlesungszeit richtet jeden Donnerstag eine andere Fachschaft oder studentische Gruppierung das Clubhausfest
-    im Clubhaus, direkt gegenüber der Neuen Aula, aus. Heute lohnt sich der Besuch jedoch ganz besonders, denn die Fachschaften
-    Informatik, Kogni und Psychologie sind Gastgeber!\\ % \\ % TODO line break wieder einfügen: Eigentlich wäre hier ein line break schöner, aber im WS24 würde dann eine einzelne Zeile auf die nächste Seite kommen
-    Keine Anmeldung nötig.\\
-    %Das anfängliche Chaos des Vorlesungsbeginns hat sich gelegt und auch an diesem Donnerstag findet das Clubhausfest statt.\\
-    \seticon{faBus}~\textbf{Bushaltestelle:} Uni/Neue Aula oder Hölderlinstraße
-\fi
-
-%Wanderung 2
-\ifml
-	\item[Hike 2 -- Saturday, October 25th \YEAR, 10:30, on the Neckarinsel (Neckar Island)]~\\
-	Time for another hike! Join us for a relaxing stroll through the beautiful Tübingen countryside.
-	This is a great chance to enjoy nature, chat with fellow students, and maybe even meet some of your professors.
-	% The meeting point is at the Neckarbrücke \emph{in front of the} restaurant \glqq Neckarmüller\grqq.\\
-	The meeting point is on the Neckarinsel.\\
-	\seticon{faBus}~\textbf{bus stop:} Neckarbrücke (lines 1--22)
-\else
-	\item[Wanderung 2 -- Samstag, 25. Oktober \YEAR, 10:30 Uhr, auf der Neckarinsel]~\\
-	Zeit für eine weitere Wanderung! Komm mit auf einen entspannten Spaziergang durch die schöne Umgebung Tübingens.
-	Bei einer gemütlichen Wanderung lernt ihr eure Kommilitonen und Kommilitoninnen
-	und vielleicht auch ein paar Dozierende kennen!
-	% Der Treffpunkt ist bei der Neckarbrücke (\emph{vor} dem Gasthaus \glqq Neckarmüller\grqq).\\
-	Der Treffpunkt ist auf der Neckarinsel.\\
-	\seticon{faBus}~\textbf{Bushaltestelle:} Neckarbrücke (Linien 1--22)
-\fi
-
-
 % Nur damit die Seite richtig gebrochen wird.
 % TODO: Muss jedes jahr angepasst werden.
 % \ifml \pagebreak \fi
 
-\ifml
-   % TODO?
-\else
-   \item[Erstihütte -- Freitag, 07. November bis Sonntag, 09. November \YEAR]~\\
-   Vom 07. bis 09. November fahren wir auf die Erstihütte in Dettingen.
-   Euch erwartet ein geselliges Programm und ein entspanntes Miteinander.
-   Weitere Informationen bezüglich Anmeldung folgen.
-\fi
-
-%Schnuppersitzung % TODO date & time
-\ifkogwiss
-    \vspace{-2.07182\baselineskip} \ \\ % to counteract the different spacing of the parbox in the line below. Remove this line if you remove the parbox and vspace in the line below
-     \item[\parbox{\linewidth}{Schnuppersitzung der fsk -- Donnerstag, 20. November \YEAR, 18:30 \\ (reguläre Sitzungen: Donnerstags, 18:30, vor dem Kogni Zimmer), Sand}]\ \vspace{.355\baselineskip} \\
-        Hoffentlich konnten wir mit unseren Veranstaltungen euer Interesse an Fachschaftsarbeit wecken.
-        Wir machen aber noch viel mehr als nur Ersti-Veranstaltungen, wir vertreten die Studierenden in Gremien,
-        sind Ansprechpartner, stellen Infrastruktur und Tools bereit und vieles mehr.
-     Komm doch einfach mal zu unserer Schnuppersitzung
-     \footnote{Natürlich freuen wir uns auch sehr, wenn du sogar schon vor der Schnuppersitzung zu regulären Sitzungen kommst :)}
-        und schau ob es dir gefällt!\\
-        Keine Anmeldung nötig.\\
-        \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
-\else
-    \ifml
-        \item[fsi trial meeting -- TBA (regular meetings: Thursdays, 18:30, Sand, A104)]~\\%Thursday, May 18th \YEAR, 18:30, Sand]~\\
-        Hopefully, we were able to arouse your interest in student council work with our events.
-        But we do much more than just first-year events, we represent the students in committees,
-        we are contact persons, provide infrastructure and tools and much more.
-        Just come to our tryout meeting\footnote{Of course we are also very happy if you already come to regular meetings before the trial session}
-        and see if you like it!\\
-        No registration necessary.\\
-        \seticon{faBus}~\textbf{bus stop:} Sand Drosselweg (bus lines 2 \& 6)
-    \else
-        \item[Schnuppersitzung der fsi -- TBA (reguläre Sitzungen: Donnerstags, 18:30, A104, Sand)]~\\%Donnerstag, 18. Mai \YEAR, 18:30 Uhr, Sand]~\\
-        Hoffentlich konnten wir mit unseren Veranstaltungen euer Interesse an Fachschaftsarbeit wecken.
-        Wir machen aber noch viel mehr als nur Ersti-Veranstaltungen, wir vertreten die Studierenden in Gremien,
-        sind Ansprechpartner, stellen Infrastruktur und Tools bereit und vieles mehr.
-        Komm doch einfach mal zu unserer Schnuppersitzung\footnote{Natürlich freuen wir uns auch sehr, wenn du sogar schon vor der Schnuppersitzung zu regulären Sitzungen kommst :)}
-        und schau ob es dir gefällt!\\
-        Keine Anmeldung nötig.\\
-        \seticon{faBus}~\textbf{Bushaltestelle:} Sand Drosselweg (Linien 2 \& 6)
-    \fi
-\fi
+% \ifml
+%    % TODO?
+% \else
+%    \item[Erstihütte -- Freitag, 07. November bis Sonntag, 09. November \YEAR]~\\
+%    Vom 07. bis 09. November fahren wir auf die Erstihütte in Dettingen.
+%    Euch erwartet ein geselliges Programm und ein entspanntes Miteinander.
+%    Weitere Informationen bezüglich Anmeldung folgen.
+% \fi
 
 
 

--- a/src/tuebingen.tex
+++ b/src/tuebingen.tex
@@ -42,10 +42,17 @@
 
     \fett{Verkehr in Tübingen}
     Die Fahrpläne für den ÖPNV  findest du online\footnote{\url{https://naldo.de}} und in der Naldo-App für Android und iOS.\\
-    Die Bushaltestelle für die Unigebäude an der \emph{Morgenstelle} (siehe Stadtplan auf der letzten Seite) heißt "`BG-Unfallklinik"'\footnote{\textbf{nicht} "`Auf der Morgenstelle"'!}). Es gibt zwar auch Parkplätze dort,
+    Die Bushaltestelle für die Unigebäude an der \emph{Morgenstelle} (siehe Stadtplan auf der letzten Seite) heißt 
+    "`BG-Unfallklinik"'\footnote{\textbf{nicht} "`Auf der Morgenstelle"'!}. Es gibt zwar auch Parkplätze dort,
     jedoch muss man deren Benutzung beantragen und die Anzahl an Parkplätzen ist ohnehin sehr begrenzt.
-    \ifmaster
-    Die meisten Master-Veranstaltungen finden auf dem Sand statt (Wilhelm-Schickard-Institut). Der Sand lässt sich mit der Buslinie 2 erreichen. Die nächstgelegene Bushaltestelle heißt "`Sand Drosselweg"'. Der Sand ist ebenfalls mit dem Auto erreichbar, allerdings werden die Parkplätze dort ab Oktober kostenpflichtig. Genauere Informationen, z.B. zu den Gebühren, haben wir aktuell leider noch nicht.    \fi
+
+
+    Die meisten Master-Veranstaltungen sowie die Vorkurse finden auf dem Sand statt (Wilhelm-Schickard-Institut). 
+    Der Sand lässt sich mit der Buslinie 2 erreichen. Die nächstgelegene Bushaltestelle heißt "`Sand Drosselweg"'. 
+    Der Sand ist ebenfalls mit dem Auto erreichbar, allerdings sind die Parkplätze genau wie an der Morgenstelle leider kostenpflichtig. 
+    Die Nutzung kostet für Studis aktuell 125€ im Semester. Achtung! Auf dem Sand gibt es keine Schranken, ihr müsst selbstständig
+    daran denken, nach der Ausfahrt bargeldlos zu zahlen. Dafür sind auf dem Sand in der Regel ausreichend viele Parkplätze verfügbar.
+
     
     Das Semesterticket kostet \semesterticketpreis~EUR und gilt im ganzen Naldogebiet, dem Verkehrsverbund rund um Tübingen (leider nicht bis Stuttgart, dafür bis Überlingen am Bodensee).
     Das Ticket gilt ab dem
@@ -76,5 +83,41 @@
     Studierendenwerk AdöR in der Wohnheimverwaltung, Fichtenweg 5, 72076 Tübingen, oder beim Studierendenwerk
     e.V., Rümelinstraße 8, 72070 Tübingen. Für den privaten Wohnungsmarkt sind Mittwochs- und Samstagsausgabe
     des Schwäbischen Tagblatts zu empfehlen.
-    Im Internet hat sich \url{www.wg-gesucht.de} etabliert. Mehr gibt es auf unserer Homepage unter \url{https://www.fsi.uni-tuebingen.de/erstsemester-faq}.
-    \fi
+    Im Internet hat sich \url{www.wg-gesucht.de} etabliert. Mehr gibt es auf unserer Homepage unter \url{https://www.fsi.uni-tuebingen.de/erstsemester-faq}. \\\\
+
+    \fett{Das Studierendenwerk (AdöR)}
+    Wie beim Thema \glqq Wohnen \grqq \ schon angeschnitten, gibt es in Tübingen zwei Studierendenwerke.
+    Du wirst meistens mit dem Studierendenwerk Adör (\textit{Anstalt des öffentlichen Rechts}) zutun haben, auch kurz \textbf{StuWe} genannt.
+    Das StuWe betreibt diverse Wohnheime, Mensen, Cafeterien, Automaten usw. in Tübingen. In den gastronomischen Einrichtungen
+    kannst du ganz bequem mit deinem Studiausweis bezahlen. Dazu lädst du im voraus Geld auf deinen Ausweis (das nennt sich \textit{Aufladen}).
+    Damit Du nicht immer zu den Aufladestationen laufen musst (die nebenbei auch technisch total veraltet sind), und auch nicht
+    regelmäßig beim Bezahlen an der Kasse noch zusätzlich mit deiner EC-Karte hantierst und den ganzen Verkehr aufhältst, raten 
+    wir \underline{dringend} zur Einrichtung von Autoload. Das geht bequem online unter \url{https://www.my-stuwe.de/autoload/}.
+    Beim Autoload-Verfahren legst du einmalig zwei Beträge X und Y fest und erteilst ein Lastschriftmandat, 
+    wobei das StuWe dann, sobald dein Guthaben auf dem Studiausweis unter Betrag X sinkt, einen Betrag Y von deinem Konto abbucht und dir gutschreibt.
+
+    Du wirst beim Einrichten feststellen, dass du die Seriennummer deines Studiausweises benötigst. Abgesehen von den Wegen, die 
+    das StuWe offiziell auf seiner Website beschreibt, kannst du diese Nummer auch mit einem NFC-fähigen Android-Smartphone auslesen.
+    Zu diesem Zweck hat die Fachschaft Informatik eine kleine Website entworfen: \url{https://sandbox.fsi.uni-tuebingen.de/\~swlt16/autoload/}
+
+    \fett{Don't panic!}
+    Die ganzen Informationen überfluten dich? Und dennoch bleiben noch Fragen offen, die dir nicht aus dem Kopf gehen?
+    Kein Problem! Das ging uns allen mal so, und das ist völlig normal wenn man in ein neues Kapitel des Lebens startet.
+    Zum Glück gibt es für die verschiedensten Fragen auch die verschiedensten Anlaufstellen:
+    \begin{itemize}
+        \item \textbf{Zentrale Studienberatung}\\
+            Die zentralisierte Studienberatung der Universität Tübingen. Bei Fragen, die nicht direkt mit dem Fach Informatik zusammenhängen,
+            sondern mit dem Studium in Tübingen im Allgemeinen, findest du hier die richtigen Ansprechpartner. \\
+            Link: \url{https://uni-tuebingen.de/studium/beratung-und-info/zentrale-studienberatung/}
+        \item \textbf{Fachstudienberatung}\\
+            Für Fragen, die eher mit der Organisation des Informatik-Studiums an sich zusammenhängen, 
+            findest du hier die richtigen Ansprechpartner. Das besondere an dieser Studienberatung ist,
+            dass sie sowohl durch Studierende als auch durch Mitarbeitende des Fachbereichs geleistet wird. \\
+            Link: \url{https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/studium/studierende/personen-und-kontakte/studienberatung/}
+        \item \textbf{Fachschaft Informatik (\textit{fsi})}\\
+            Natürlich kannst du dich auch immer gern an uns wenden. Dabei reicht das Spektrum von \textit{Wie schwierig ist Vorlesung X?} 
+            bis hin zu \textit{Wo kann man in Tübingen gut Bier trinken?}. Im Zweifel können wir als Ehrenamtliche natürlich nicht alle
+            Fragen beantworten - Aber meistens wissen wir immerhin, wer es kann. :-)
+
+    \end{itemize}
+\fi

--- a/stundenplaene/stpl_bioinfo-bsc_SS.tex
+++ b/stundenplaene/stpl_bioinfo-bsc_SS.tex
@@ -9,7 +9,7 @@ Semester neben den Informatik- und Biochemie-Vorlesungen auch eine gute Portion 
         08 -- 09 &               &                          &               &                          &                    \\ \hline
         09 -- 10 &               &                          &               &                          &                    \\ \hline
         10 -- 11 & Mathematik II &                          & Mathematik II &                          & Biochemie          \\ \cline{1-1} \cline{3-3} \cline{5-5}
-        11 -- 12 & (\Matheprof)  &                          & (\Matheprof)  & Biochemie                & (Prof. Nürnberger) \\ \hline
+        11 -- 12 & (\Matheprof)  &                          & (\Matheprof)  & Biochemie                & (\Biochemieprof)   \\ \hline
         12 -- 13 &               &                          &               &                          &                    \\ \cline{1-3} \cline{5-6}
         13 -- 14 &               &                          & Mathe         &Einf. in die Bioinformatik\footnotemark &                    \\ \cline{1-3} \cline{5-6}
         14 -- 15 &               & Praktische Informatik II & Rechenzentrum & Praktische Informatik II &                    \\ \cline{1-2} \cline{6-6}
@@ -23,21 +23,3 @@ Semester neben den Informatik- und Biochemie-Vorlesungen auch eine gute Portion 
 \end{center}
 \footnotetext{Einführung in die Bioinformatik (Prof. Thiel)}
 \noindent Dieser Plan gilt für das zweite Semester Bioinformatik, für euch ist es jedoch das Erste.\\
-
-\textbf{Mathe 2}:\\
-Vollständiger Name: Mathematik für Informatik 2: Lineare Algebra\\
-Dieses Semester wird die Vorlesung im Hörsaal N7 auf der Morgenstelle stattfinden.
-Zusätzlich zur Vorlesung findet ein Tutorium statt. \\
-Ab dem 24.04. findet mittwochs das Rechenzentrum statt. Hier können Studierende gemeinsam die Aufgaben und Inhalte der Vorlesung diskutieren,
-wobei auch Tutorinnen und Tutoren anwesend sein werden. Die Teilnahme am Rechenzentrum ist freiwillig.\\
-
-\textbf{Info 2}:\\
-Vollständiger Name: Praktische Informatik 2: Imperative und objektorientierte Programmierung\\
-Dieses Semester wird die Vorlesung wieder in Präsenz im Hörsaal N7 auf der Morgenstelle stattfinden.
-Zusätzlich werden Tutorien in Präsenz stattfinden.
-Die Zeiten für die Tutorien werden innerhalb der ersten Woche in den Vorlesungen bekannt gegeben.\\
-% Es wird für die Mathe II und die Info II auch noch freiwillige Zusatz-Tutorium und Einführungskurse geben.\\
-
-\textbf{üBK}:\\
-Im Studienplan wird empfohlen übK\footnote{überfachlich berufsfeldorientierte Kompetenzen, in Zukunft auch Liberal Education genannt}
-mit (insgesamt) 3-6 LP zu belegen. Hier ist dir völlig freigestellt was du belegst, solange es mit ECTS Punkten versehen, benotet und kein Sport ist.\\

--- a/stundenplaene/stpl_informatik-bsc_SS.tex
+++ b/stundenplaene/stpl_informatik-bsc_SS.tex
@@ -43,23 +43,3 @@ Semester neben der Informatikvorlesung auch eine gute Portion Mathe.
 \end{center}
 \noindent Dieser Plan gilt für das zweite Semester Informatik, für euch ist es jedoch das erste.\\
 
-\textbf{Mathe 2}:\\
-Vollständiger Name: Mathematik für Informatik 2: Lineare Algebra\\
-Dieses Semester wird die Vorlesung im Hörsaal N7 auf der Morgenstelle stattfinden.
-Zusätzlich zur Vorlesung findet ein Tutorium statt. \\
-Ab dem 24.04. findet mittwochs das Rechenzentrum statt. Hier können Studierende gemeinsam die Aufgaben und Inhalte der Vorlesung diskutieren,
-wobei auch Tutorinnen und Tutoren anwesend sein werden. Die Teilnahme am Rechenzentrum ist freiwillig.\\
-
-\textbf{Info 2}:\\
-Vollständiger Name: Praktische Informatik 2: Imperative und objektorientierte Programmierung\\
-Dieses Semester wird die Vorlesung wieder in Präsenz im Hörsaal N7 auf der Morgenstelle stattfinden.
-Zusätzlich werden Tutorien in Präsenz stattfinden.
-Die Zeiten für die Tutorien werden innerhalb der ersten Woche in den Vorlesungen bekannt gegeben.\\
-% Es wird für die Mathe II und die Info II auch noch freiwillige Zusatz-Tutorium und Einführungskurse geben.\\
-
-\textbf{üBK}:\\
-Im Studienplan wird empfohlen eine übK\footnote{überfachlich berufsfeldorientierte Kompetenzen, in Zukunft auch Liberal Education genannt}
-mit 3 LP zu belegen. Hier ist dir völlig freigestellt was du belegst, solange es mit ECTS Punkten versehen, benotet und kein Sport ist.
-Veranstaltung von gewissen Fächern (u.a. Medizin, Phsychologie) lassen sich jedoch nur hören, wenn du dieses als Schwerpunktfach gewählt hast.
-Hierdurch verlierst du jedoch die Freiheit der übK und darfst nur Vorlesungen aus diesen Fächern hören. Näheres erfährst du bei der fachspezifischen Begrüßung.
-

--- a/stundenplaene/stpl_informatik-lehramt_SS.tex
+++ b/stundenplaene/stpl_informatik-lehramt_SS.tex
@@ -1,28 +1,25 @@
-Wie du dem folgenden Stundenplan entnehmen kannst, enthält das Lehramtsstudium der Informatik im ersten Semester zunächst nur die Informatik II und Fachdidaktik-Vorlesung.
+Wie du dem folgenden Stundenplan entnehmen kannst, enthält das Lehramtsstudium der Informatik im ersten Semester zunächst nur die Praktische Informatik II und Fachdidaktik-Vorlesung.
 Beachte, dass man auch pädagogische Studien schon im ersten Semester besuchen kann. Falls sich Veranstaltungen aus dem zweiten
-Fach mit Informatik überschneiden, kann man v.a. Informatik der Systeme aus dem vierten Semester tauschen.
+Fach mit Informatik überschneiden, kann man v.a. Technische Informatik II aus dem vierten Semester tauschen.
 Wenn du dir noch einen genaueren Überblick über den Studienverlauf verschaffen möchtest, dann schau doch mal ins Modulhandbuch.
 
 \begin{center}
-	\begin{tabular}{|c|c|c|c|}
-		\hline
-		Zeit     & Dienstag                   & Mittwoch & Donnerstag               \\ \hline
-		08 -- 09 &                            &          &                          \\ \hline
-		09 -- 10 &                            &          &                          \\ \hline
-		10 -- 11 &                            &          &                          \\ \hline
-		11 -- 12 &                            &          &                          \\ \hline
-		12 -- 13 &                            &          &                          \\ \hline
-		13 -- 14 &                            &          &                          \\ \hline
-		14 -- 15 & Praktische Informatik II   &          & Praktische Informatik II \\ \cline{1-1} \cline{3-3}
-		15 -- 16 & (\Infoprof)                &          & (\Infoprof)              \\ \hline
-		16 -- 17 &                            &          & Fachdidaktik 1           \\ \cline{1-3}
-		17 -- 18 &                            &          & Dr. Appel (ab 17.04.)    \\ \hline
-		\end{tabular}
-
+    % Reguläres Semester
+    \resizebox{\textwidth}{!}{
+    \begin{tabular}{|c|c|c|c|c|c|}
+       \hline
+       Zeit     & Montag                   & Dienstag                            & Mittwoch      & Donnerstag               & Freitag \\ \hline
+       08 -- 09 &                          & \textit{Technische Informatik II}   &               &                          &         \\ \cline{1-2} \cline{4-6}
+       09 -- 10 &                          & \textit{(\TechInfoprof)}            &               &                          &         \\ \hline
+       10 -- 11 &                          &                                     &               &                          &         \\ \hline
+       11 -- 12 &                          &                                     &               &                          &         \\ \hline
+       12 -- 13 &                          &                                     &               &                          &         \\ \hline
+       13 -- 14 &                          &                                     &               &                          &         \\ \hline
+       14 -- 15 &                          & Praktische Informatik II            &               & Praktische Informatik II &         \\ \cline{1-2} \cline{4-4} \cline{6-6}
+       15 -- 16 &                          & (\Infoprof)                         &               & (\Infoprof)              &         \\ \hline
+       16 -- 17 & \textit{Technische}      & Fachdidaktik I                      &               &                          &         \\ \cline{1-1} \cline{4-6}
+       17 -- 18 & \textit{Informatik II}   & (\Didaktikprof)                     &               &                          &         \\ \cline{1-1} \cline{3-6}
+       18 -- 19 & \textit{(\TechInfoprof)} &                                     &               &                          &         \\ \hline
+    \end{tabular}
+    }
 \end{center}
-
-\textbf{Info 2}:\\
-Vollständiger Name: Praktische Informatik 2: Imperative und objektorientierte Programmierung\\
-Dieses Semester wird die Vorlesung wieder in Präsenz im Hörsaal N7 auf der Morgenstelle stattfinden.
-Zusätzlich werden Tutorien in Präsenz stattfinden.
-Die Zeiten für die Tutorien werden innerhalb der ersten Woche in den Vorlesungen bekannt gegeben.\\


### PR DESCRIPTION
* updated precourses
* updated appointments for the beginners
* cleaned up the timetables and the course descriptions
* removed kogni references for the summer term
* add information about parking at the Sand (addresses fsi-tue#75)
* add a section about StuWe and autoload
* add a section about 'studienberatung' (addresses fsi-tue#82)
* changed the redaction hint a little bit